### PR TITLE
Store `Outline` until `Example` block is given

### DIFF
--- a/Example/Tests/Features/ExampleFeatures.swift
+++ b/Example/Tests/Features/ExampleFeatures.swift
@@ -34,8 +34,8 @@ class ExampleFeatures: XCTestCase {
         )
         
         Outline {
-            Given("I use the example name <name>")
-            Then("The age should be <age>")
+            self.Given("I use the example name <name>")
+            self.Then("The age should be <age>")
         }
     }
     
@@ -49,8 +49,8 @@ class ExampleFeatures: XCTestCase {
         Examples(examples)
         
         Outline {
-            Given("I use the example name <name>")
-            Then("The age should be <age>")
+            self.Given("I use the example name <name>")
+            self.Then("The age should be <age>")
         }
     }
 
@@ -58,21 +58,21 @@ class ExampleFeatures: XCTestCase {
         Examples(examples)
         
         Outline {
-            Given("I use the example name <name>")
-            Then("The height should be <height>")
+            self.Given("I use the example name <name>")
+            self.Then("The height should be <height>")
         }
     }
 
     func testExamplesAfterOutline() {
         Outline {
-            Given("I use the example name <name>")
-            Then("The height should be <height>")
+            self.Given("I use the example name <name>")
+            self.Then("The height should be <height>")
         }
 
         Examples(
-            [ "name", "age" ],
-            [ "Alice", "20" ],
-            [ "Bob", "20" ]
+            [ "name",   "age", "height" ],
+            [ "Alice",  "20",  "170"   ],
+            [ "Bob",    "20",  "170"   ]
         )
     }
 

--- a/Example/Tests/Features/ExampleFeatures.swift
+++ b/Example/Tests/Features/ExampleFeatures.swift
@@ -63,4 +63,17 @@ class ExampleFeatures: XCTestCase {
         }
     }
 
+    func testExamplesAfterOutline() {
+        Outline {
+            Given("I use the example name <name>")
+            Then("The height should be <height>")
+        }
+
+        Examples(
+            [ "name", "age" ],
+            [ "Alice", "20" ],
+            [ "Bob", "20" ]
+        )
+    }
+
 }

--- a/Pod/Core/Example.swift
+++ b/Pod/Core/Example.swift
@@ -16,4 +16,4 @@ typealias ExampleValue = String
 /**
  An Example represents a single row in the Examples(...) block in a test
  */
-typealias Example = [ExampleTitle:ExampleValue]
+typealias Example = [ExampleTitle: ExampleValue]


### PR DESCRIPTION
This fixes #12 and lets us put examples after the outline - as in the feature file spec.

Unfortunately, this means we lost the `@noescape` flag on the Outline method, which has a side effect of needing to add `self.` before all the Given / When etc. Sigh. We should chat though this to see if the benefit of conforming more closely to the Gherkin spec is worth all that extra cruft!

S
