### PR TITLE
Patch 1 - Re-wrote StringGherkinExtension.swift extensions in native Swift 

### DIFF
--- a/Pod/Core/StringGherkinExtension.swift
+++ b/Pod/Core/StringGherkinExtension.swift
@@ -35,8 +35,9 @@ public extension String {
     */
     var uppercaseFirstLetterString: String {
         get {
-            guard case var c = self.characters where c.count > 0 else { return self }
-            return String(c.removeFirst()).uppercaseString + String(c)
+            guard case let c = self.characters,
+                let c1 = c.first else { return self }
+            return String(c1).uppercaseString + String(c.dropFirst())
         }
     }
     
@@ -47,8 +48,9 @@ public extension String {
      */
     var humanReadableString: String {
         get {
-            guard case var c = self.characters where c.count > 1 else { return self }
-            return String(c.removeFirst()) + c.reduce("") { (sum, c) in
+            guard case let c = self.characters where c.count > 1,
+                let c1 = c.first else { return self }
+            return String(c1) + c.dropFirst().reduce("") { (sum, c) in
                 let s = String(c)
                 if s == s.uppercaseString {
                     return sum + " " + s

--- a/Pod/Core/StringGherkinExtension.swift
+++ b/Pod/Core/StringGherkinExtension.swift
@@ -18,17 +18,12 @@ public extension String {
     */
     var camelCaseify: String {
         get {
-            let separators = NSCharacterSet(charactersInString: " -")
-            if self.rangeOfCharacterFromSet(separators) == nil {
+            guard case let c = (self.characters.split { $0 == " " || $0 == "-" })
+                where c.count > 1 else {
                 return self.uppercaseFirstLetterString
             }
-            return self.lowercaseString.componentsSeparatedByCharactersInSet(separators).filter {
-                // Empty sections aren't interesting
-                $0.characters.count > 0
-            }.map {
-                // Uppercase each word
-                $0.uppercaseFirstLetterString
-            }.joinWithSeparator("")
+            return c.map { String($0).lowercaseString.uppercaseFirstLetterString }
+                .joinWithSeparator("")
         }
     }
 
@@ -40,11 +35,8 @@ public extension String {
     */
     var uppercaseFirstLetterString: String {
         get {
-            let s = self as NSString
-            guard s.length>0 else {
-                return self
-            }
-            return s.substringToIndex(1).uppercaseString.stringByAppendingString(s.substringFromIndex(1))
+            guard case var c = self.characters where c.count > 0 else { return self }
+            return String(c.removeFirst()).uppercaseString + String(c)
         }
     }
     
@@ -55,24 +47,16 @@ public extension String {
      */
     var humanReadableString: String {
         get {
-            // This is probably easier in NSStringland
-            let s = self as NSString
-            
-            // The output string can start with the first letter
-            var o = s.substringToIndex(1)
-            
-            // For each other letter, if it's the same as it's uppercase counterpart, insert a space before it
-            for i in 1..<s.length {
-                let l = s.substringWithRange(NSMakeRange(i, 1))
-                let u = l.uppercaseString
-                
-                if (u == l) {
-                    o += " "
+            guard case var c = self.characters where c.count > 1 else { return self }
+            return String(c.removeFirst()) + c.reduce("") { (sum, c) in
+                let s = String(c)
+                if s == s.uppercaseString {
+                    return sum + " " + s
                 }
-                
-                o += l
-            }            
-            return o
+                else {
+                    return sum + s
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Previously discussed [in this closed PR](https://github.com/net-a-porter-mobile/XCTest-Gherkin/pull/15) (was a bit too quick deleting the branch of the previous PR, hence a new PR rather than re-opening the old one).

PR contains 2 commits, each using slightly different methods for the `.uppercaseFirstLetterString` and `.humanReadableString` computed properties, where the latter commit, imho, is to be preferred.