### PR TITLE
Feature/filter comments tags whitelines

### DIFF
--- a/Example/Tests/Features/NativeFeatures/native_example.feature
+++ b/Example/Tests/Features/NativeFeatures/native_example.feature
@@ -1,3 +1,7 @@
+# Comment line 1
+# Comment line 2
+@tag
+
 Feature: Feature file parsing
 
     Scenario: This is a basic happy path example

--- a/Pod/Native/NativeFeature.swift
+++ b/Pod/Native/NativeFeature.swift
@@ -42,17 +42,16 @@ extension NativeFeature {
         // Read in the file
         let contents = try! NSString(contentsOfURL: url, encoding: NSUTF8StringEncoding)
         
-        // Get all the lines in the file
-        let lines = contents.componentsSeparatedByString("\n")
-            .map { $0.stringByTrimmingCharactersInSet(whitespace) }
-        
+        // Get all the lines in the file 
+        var lines = contents.componentsSeparatedByString("\n").map { $0.stringByTrimmingCharactersInSet(whitespace) }
+        // Filter comments (#) and tags (@), also filter white lines
+        lines = lines.filter { $0.characters.first != "#" &&  $0.characters.first != "@" && $0.characters.count > 0}
+
         guard lines.count > 0 else { return nil }
         
         // The feature description needs to be on the first line - we'll fail this method if it isn't!
         let (_,suffixOption) = lines.first!.componentsWithPrefix(FileTags.Feature)
-        guard let suffix = suffixOption else { return nil }
-
-        let featureDescription = suffix
+        guard let featureDescription = suffixOption else { return nil }
         
         let scenarios = NativeFeature.parseLines(lines)
         

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -47,6 +47,8 @@ public class NativeTestCase : XCTestCase {
         files.forEach {
             if let feature = NativeFeature(contentsOfURL:($0 as! NSURL), stepChecker:stepChecker){
                 features.append(feature)
+            } else {
+                XCTFail("Could not parse feature at URL \(($0 as! NSURL).description)")
             }
         }
         if !stepChecker.printTemplateCodeForAllMissingSteps() {


### PR DESCRIPTION
Sometimes native feature files written in Gherkin contain comments, tags or white lines at the top of the files. These are not allowed by the parser now. This pull request filters out any comment, tag or line with no characters before parsing the Gherkin lines.