### PR TITLE
feature/parse-gherkin-background-keyword

### DIFF
--- a/Example/Tests/Features/ExampleNativeTest.swift
+++ b/Example/Tests/Features/ExampleNativeTest.swift
@@ -18,6 +18,8 @@ class ExampleNativeTest : NativeTestCase {
         self.path = bundle.resourceURL?.URLByAppendingPathComponent("NativeFeatures")
         
         XCTAssertNotNil(self.path)
+        
+        ColorLog.enabled = true
     }
     
 }

--- a/Example/Tests/Features/NativeFeatures/native_example.feature
+++ b/Example/Tests/Features/NativeFeatures/native_example.feature
@@ -4,6 +4,10 @@
 
 Feature: Feature file parsing
 
+    Background:
+        Given I have duplicate steps at the start of every scenario
+        Then I should move these steps to the background section
+
     Scenario: This is a basic happy path example
         Given I have a working Gherkin environment
         Then this test should not fail

--- a/Example/Tests/Features/NativeFeatures/native_example_simple.feature
+++ b/Example/Tests/Features/NativeFeatures/native_example_simple.feature
@@ -1,0 +1,6 @@
+Feature: Simple Feature File Parsing
+
+    Scenario: This is a basic happy path example
+        Given I have a working Gherkin environment
+        Then this test should not fail
+

--- a/Example/Tests/StepDefinitions/SanitySteps.swift
+++ b/Example/Tests/StepDefinitions/SanitySteps.swift
@@ -13,8 +13,16 @@ class SanitySteps : StepDefiner {
     
     override func defineSteps() {
         
-        // Example of defining a step with no capture groups
+        // Examples of defining a step with no capture groups
         step("I have a working Gherkin environment") {
+            XCTAssertTrue(true)
+        }
+        
+        step("I have duplicate steps at the start of every scenario") {
+            XCTAssertTrue(true)
+        }
+        
+        step("I should move these steps to the background section") {
             XCTAssertTrue(true)
         }
         

--- a/Pod/Native/NativeScenario.swift
+++ b/Pod/Native/NativeScenario.swift
@@ -35,3 +35,8 @@ class NativeScenario : CustomStringConvertible {
         }
     }
 }
+
+// The "Background" is a number of steps executed before every scenario, so this can be modelled as another scenario.
+class NativeBackground : NativeScenario {
+    
+}

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -89,6 +89,8 @@ public class NativeTestCase : XCTestCase {
         success = class_addMethod(testCaseClass, runSel, runImp, strdup("#@:"))
         XCTAssertTrue(success)
         
+        NSLog(feature.description)
+        
         // For each scenario, make an invocation that runs through the steps
         let typeString = strdup("v@:")
         feature.scenarios.forEach { scenario in
@@ -96,6 +98,9 @@ public class NativeTestCase : XCTestCase {
             
             // Create the block representing the test to be run
             let block : @convention(block) (XCTestCase)->() = { innerSelf in
+                if let background = feature.background {
+                    background.stepDescriptions.forEach { innerSelf.performStep($0) }
+                }
                 scenario.stepDescriptions.forEach { innerSelf.performStep($0) }
             }
             

--- a/Pod/Native/ParseState.swift
+++ b/Pod/Native/ParseState.swift
@@ -14,15 +14,17 @@ class ParseState {
     var description: String?
     var steps: [String]
     var exampleLines: [ (lineNumber:Int, line:String) ]
-    
+    var parsingBackground: Bool
+
     convenience init() {
         self.init(description: nil)
     }
     
-    required init(description: String?) {
+    required init(description: String?, parsingBackground: Bool = false) {
         self.description = description
         steps = []
         exampleLines = []
+        self.parsingBackground = parsingBackground
     }
     
     private var examples:[NativeExample] {
@@ -55,9 +57,14 @@ class ParseState {
         }
     }
     
+    func background() -> NativeBackground? {
+        guard parsingBackground, let description = self.description where self.steps.count > 0 else { return nil }
+        
+        return NativeBackground(description, steps: self.steps)
+    }
+    
     func scenarios() -> [NativeScenario]? {
-        guard let d = self.description else { return nil }
-        guard self.steps.count > 0 else { return nil }
+        guard let description = self.description where self.steps.count > 0 else { return nil }
         
         var scenarios = Array<NativeScenario>()
         
@@ -66,8 +73,8 @@ class ParseState {
             // Replace each matching placeholder in each line with the example data
             self.examples.forEach { example in
                 
-                // This hoop is beacuse the compiler doesn't seem to
-                // recognize mapdirectly on the state.steps object
+                // This hoop is because the compiler doesn't seem to
+                // recognize map directly on the state.steps object
                 var steps = self.steps
                 steps = self.steps.map { originalStep in
                     var step = originalStep
@@ -80,12 +87,12 @@ class ParseState {
                 }
                 
                 // The scenario description must be unique
-                let description = "\(d)_line\(example.lineNumber)"
+                let description = "\(description)_line\(example.lineNumber)"
                 scenarios.append(NativeScenario(description, steps: steps))
                 
             }
         } else {
-            scenarios.append(NativeScenario(d, steps: self.steps))
+            scenarios.append(NativeScenario(description, steps: self.steps))
         }
         
         self.description = nil


### PR DESCRIPTION
As described on https://cucumber.io/docs/reference#gherkin you can use the Background keyword at the top of your feature file:

> Occasionally you'll find yourself repeating the same Given steps in all of the scenarios in a feature file. Since it is repeated in every scenario it is an indication that those steps are not essential to describe the scenarios, they are incidental details.
> 
> You can literally move such Given steps to the background by grouping them under a Background section before the first scenario.

We added support for this in the Gherkin feature file parser of native gherkin files. 