### PR TITLE
Partially matching expressions fix

### DIFF
--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -214,10 +214,12 @@ extension XCTestCase {
         let range = NSMakeRange(0, expression.characters.count)
         let matches = state.steps.map { (step: Step) -> (step:Step, match:NSTextCheckingResult)? in
             if let match = step.regex.firstMatchInString(expression, options: [], range: range) {
-                return (step:step, match:match)
-            } else {
-                return nil
+                // We don't want the strings to be only partially matching
+                if match.range.length == range.length {
+                    return (step:step, match:match)
+                }
             }
+            return nil
         }.flatMap { $0! }
 
         // Get the step and the matches inside it

--- a/Pod/Core/XCTestCase+GherkinStepsChecker.swift
+++ b/Pod/Core/XCTestCase+GherkinStepsChecker.swift
@@ -22,11 +22,14 @@ class GherkinStepsChecker: XCTestCase {
         // Get the step(s) which match this expression
         let range = NSMakeRange(0, expression.characters.count)
         let matches = state.steps.map { (step: Step) -> (step:Step, match:NSTextCheckingResult)? in
+            // TODO: consider refactor - code duplication in XCTestCase+Gherkin: 216
             if let match = step.regex.firstMatchInString(expression, options: [], range: range) {
-                return (step:step, match:match)
-            } else {
-                return nil
+                // We don't want the strings to be only partially matching
+                if match.range.length == range.length {
+                    return (step:step, match:match)
+                }
             }
+            return nil
             }.flatMap { $0! }
         
         switch matches.count {


### PR DESCRIPTION
Just a small fix to the issue I was stumbling upon.
I had "I select all checks but bodywork" step in the scenarios (but not in StepDefiner) and the framework was matching it against similar step definition: "I select all checks" instead of throwing a fatalError.