### PR TITLE
Improvement/rename windows new line char in native feature file

### DIFF
--- a/Example/Tests/Features/ExampleNativeFeatureTest.swift
+++ b/Example/Tests/Features/ExampleNativeFeatureTest.swift
@@ -9,7 +9,7 @@
 import XCTest
 import XCTest_Gherkin
 
-class ExampleNativeFeatureTest: NativeTestCase {
+class RunSingleFeatureFileTest: NativeTestCase {
 
     override func setUp() {
         super.setUp()
@@ -19,7 +19,15 @@ class ExampleNativeFeatureTest: NativeTestCase {
         // In case you want to use only one feature file instead of the whole folder
         // Just provide the URL to the file
         self.path = bundle.resourceURL?.URLByAppendingPathComponent("NativeFeatures/native_example.feature")
+    }
+}
+
+class RunMultipleFeatureFilesTest: NativeTestCase {
+    
+    override func setUp() {
+        super.setUp()
         
-        XCTAssertNotNil(self.path)
+        let bundle = NSBundle(forClass: self.dynamicType)
+        self.path = bundle.resourceURL?.URLByAppendingPathComponent("NativeFeatures/")
     }
 }

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -32,6 +32,9 @@ class GherkinState {
     
     // Store the name of the current test to help debugging output
     var currentTestName:String = "NO TESTS RUN YET"
+    
+    // The Gherkin Steps Checker checks if all Gherkin steps have been implemented in a StepDefiner subclass.
+    let stepChecker = GherkinStepsChecker()
 }
 
 /**
@@ -222,10 +225,9 @@ extension XCTestCase {
 
         // Get the step and the matches inside it
         guard let (step, match) = matches.first else {
-            let stepChecker = GherkinStepsChecker()
-            stepChecker.matchGherkinStepExpressionToStepDefinitions(expression)
-            stepChecker.printTemplateCodeForAllMissingSteps()
-            fatalError()
+            state.stepChecker.matchGherkinStepExpressionToStepDefinitions(expression)
+            state.stepChecker.shouldPrintTemplateCodeForAllMissingSteps()
+            fatalError("failed to find a match for a step")
         }
         
         // Covert them to strings to pass back into the step function

--- a/Pod/Core/XCTestCase+GherkinStepsChecker.swift
+++ b/Pod/Core/XCTestCase+GherkinStepsChecker.swift
@@ -47,7 +47,7 @@ class GherkinStepsChecker: XCTestCase {
         
     }
     
-    func printTemplateCodeForAllMissingSteps() -> Bool {
+    func shouldPrintTemplateCodeForAllMissingSteps() -> Bool {
         guard missingStepsImplementations.count > 0 else {
             ColorLog.lightGreen("All Gherkin steps have been defined in a StepDefiner subclass")
             return false

--- a/Pod/Native/NativeFeature.swift
+++ b/Pod/Native/NativeFeature.swift
@@ -49,8 +49,12 @@ extension NativeFeature {
         // Read in the file
         let contents = try! NSString(contentsOfURL: url, encoding: NSUTF8StringEncoding)
         
-        // Get all the lines in the file 
-        var lines = contents.componentsSeparatedByString("\n").map { $0.stringByTrimmingCharactersInSet(whitespace) }
+        // Replace new line character that is sometimes used if the Gherkin files have been written on a Windows machine.
+        let contentsFixedWindowsNewLineCharacters = contents.stringByReplacingOccurrencesOfString("\r\n", withString: "\n")
+        
+        // Get all the lines in the file
+        var lines = contentsFixedWindowsNewLineCharacters.componentsSeparatedByString("\n").map { $0.stringByTrimmingCharactersInSet(whitespace) }
+
         // Filter comments (#) and tags (@), also filter white lines
         lines = lines.filter { $0.characters.first != "#" &&  $0.characters.first != "@" && $0.characters.count > 0}
 

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -16,10 +16,6 @@ public class NativeTestCase : XCTestCase {
     public var path:NSURL?
     public func setUpBeforeScenario() {}
     
-    /*
-     The Gherkin Steps Checker checks if all Gherkin steps have been implemented in a StepDefiner subclass.
-     */
-    let stepChecker = GherkinStepsChecker()
     var testCaseClass: AnyClass!
     
     /**
@@ -72,7 +68,7 @@ public class NativeTestCase : XCTestCase {
     }
     
     func parseFeatureFile(file: NSURL) -> NativeFeature? {
-        guard let feature = NativeFeature(contentsOfURL:file, stepChecker:stepChecker) else {
+        guard let feature = NativeFeature(contentsOfURL:file, stepChecker:state.stepChecker) else {
             XCTFail("Could not parse feature at URL \(file.description)")
             return nil
         }
@@ -80,7 +76,7 @@ public class NativeTestCase : XCTestCase {
     }
     
     func perform(features: [NativeFeature]) {
-        if !stepChecker.printTemplateCodeForAllMissingSteps() {
+        if !state.stepChecker.shouldPrintTemplateCodeForAllMissingSteps() {
             features.forEach({performFeature($0)})
         }
     }


### PR DESCRIPTION
I ran in an issue where I was trying to parse a native feature file that contained as a \r\n new line character. Our Gherkin files get written in all sorts of environments, and some of those use that new line character. Since \r\n and \n are the only options for new line character I chose as solution to just replace any occurrence of \r\n by \n.

I added a minor refactoring on the GherkinStepChecker to the pull request. It was initialised twice, and because it checks the steps it seemed an improvement to me to move it to a central place, the GherkinState.

Because this is not a full fledged feature, but a slight modification, I thought it was OK to create this pull request before discussing it as mentioned in the guidelines for contributing.