### PR TITLE
Feature/native setup support

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		DCE7A9658F5E70721D0B5F699DE8E402 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAC405455F8E20BD0434D9D3E3D2879A /* Foundation.framework */; };
 		DED7FBE4FC3F96EA438A93E1613C4F5C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAC405455F8E20BD0434D9D3E3D2879A /* Foundation.framework */; };
 		E86E4C08BDC160B4DD94EAF45D845DCB /* StepDefiner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F581E2C2F6BE66B51311FAB0C2B70003 /* StepDefiner.swift */; };
+		E8F874891D7D7CF3006F24F1 /* NativeFeatureParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F874871D7D7C66006F24F1 /* NativeFeatureParser.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -113,6 +114,7 @@
 		D30C51B2CC7305E1EF8D5DC05EBE89EA /* ParseState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ParseState.swift; sourceTree = "<group>"; };
 		E326D40896C53E3008ACD662D43211CF /* Pods-XCTest-Gherkin_Example-XCTest-Gherkin_ExampleUITests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-XCTest-Gherkin_Example-XCTest-Gherkin_ExampleUITests-dummy.m"; sourceTree = "<group>"; };
 		E6E43EAD4D634C9F4494E0C83C0F6266 /* NativeExample.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NativeExample.swift; sourceTree = "<group>"; };
+		E8F874871D7D7C66006F24F1 /* NativeFeatureParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeFeatureParser.swift; sourceTree = "<group>"; };
 		F581E2C2F6BE66B51311FAB0C2B70003 /* StepDefiner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StepDefiner.swift; sourceTree = "<group>"; };
 		F973A82432BA78F7218B67A72EA67660 /* XCTest-Gherkin.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "XCTest-Gherkin.xcconfig"; sourceTree = "<group>"; };
 		FDBBC44174316E15927146CBD8FFAF23 /* StringGherkinExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringGherkinExtension.swift; sourceTree = "<group>"; };
@@ -163,6 +165,7 @@
 				797F51BB058B8D9B398B2F63C0A18AF0 /* NativeScenario.swift */,
 				856F6DD3258B844A7976F574E87743A8 /* NativeTestCase.swift */,
 				D30C51B2CC7305E1EF8D5DC05EBE89EA /* ParseState.swift */,
+				E8F874871D7D7C66006F24F1 /* NativeFeatureParser.swift */,
 			);
 			path = Native;
 			sourceTree = "<group>";
@@ -517,6 +520,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E8F874891D7D7CF3006F24F1 /* NativeFeatureParser.swift in Sources */,
 				AD553C04127F6895F6D266214CEAF0A1 /* ClassHelperMethods.swift in Sources */,
 				4986EFD4B8EDC771D491968E40312B06 /* ColorLog.swift in Sources */,
 				24696F2F6F99B32698D3DCE5B5FE44DA /* Example.swift in Sources */,
@@ -630,6 +634,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CAA3796B92E5A32F2035E8DA6507759E /* Pods-XCTest-Gherkin_Example.release.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -797,6 +802,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7153B019BA00AED2AC2594193AB33FC0 /* Pods-XCTest-Gherkin_Example.debug.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;

--- a/Example/Tests/Features/ExampleNativeFeatureTest.swift
+++ b/Example/Tests/Features/ExampleNativeFeatureTest.swift
@@ -10,24 +10,15 @@ import XCTest
 import XCTest_Gherkin
 
 class RunSingleFeatureFileTest: NativeTestCase {
-
-    override func setUp() {
-        super.setUp()
-        
-        let bundle = NSBundle(forClass: self.dynamicType)
-        
-        // In case you want to use only one feature file instead of the whole folder
-        // Just provide the URL to the file
-        self.path = bundle.resourceURL?.URLByAppendingPathComponent("NativeFeatures/native_example.feature")
+    override class func path() -> NSURL? {
+        let bundle = NSBundle(forClass: self)
+        return  bundle.resourceURL?.URLByAppendingPathComponent("NativeFeatures/native_example.feature")
     }
 }
 
 class RunMultipleFeatureFilesTest: NativeTestCase {
-    
-    override func setUp() {
-        super.setUp()
-        
-        let bundle = NSBundle(forClass: self.dynamicType)
-        self.path = bundle.resourceURL?.URLByAppendingPathComponent("NativeFeatures/")
+    override class func path() -> NSURL? {
+        let bundle = NSBundle(forClass: self)
+        return bundle.resourceURL?.URLByAppendingPathComponent("NativeFeatures/")
     }
 }

--- a/Example/Tests/Features/ExampleNativeFeatureTest.swift
+++ b/Example/Tests/Features/ExampleNativeFeatureTest.swift
@@ -12,7 +12,7 @@ import XCTest_Gherkin
 class RunSingleFeatureFileTest: NativeTestCase {
     override class func path() -> NSURL? {
         let bundle = NSBundle(forClass: self)
-        return  bundle.resourceURL?.URLByAppendingPathComponent("NativeFeatures/native_example.feature")
+        return  bundle.resourceURL?.URLByAppendingPathComponent("NativeFeatures/native_example_simple.feature")
     }
 }
 

--- a/Example/Tests/Features/ExampleNativeTest.swift
+++ b/Example/Tests/Features/ExampleNativeTest.swift
@@ -12,7 +12,7 @@ import XCTest_Gherkin
 class ExampleNativeTest : NativeTestCase {
     override class func path() -> NSURL? {
         let bundle = NSBundle(forClass: self)
-        return bundle.resourceURL?.URLByAppendingPathComponent("NativeFeatures")
+        return bundle.resourceURL?.URLByAppendingPathComponent("NativeFeatures/native_example.feature")
     }
     
     override func setUp() {

--- a/Example/Tests/Features/ExampleNativeTest.swift
+++ b/Example/Tests/Features/ExampleNativeTest.swift
@@ -10,20 +10,18 @@ import XCTest
 import XCTest_Gherkin
 
 class ExampleNativeTest : NativeTestCase {
-
+    override class func path() -> NSURL? {
+        let bundle = NSBundle(forClass: self)
+        return bundle.resourceURL?.URLByAppendingPathComponent("NativeFeatures")
+    }
+    
     override func setUp() {
         super.setUp()
-        
-        let bundle = NSBundle(forClass: self.dynamicType)
-        self.path = bundle.resourceURL?.URLByAppendingPathComponent("NativeFeatures")
-        
-        XCTAssertNotNil(self.path)
-        
+        print("Default setup method works before each native scenario")
         ColorLog.enabled = true
     }
     
-    override func setUpBeforeScenario() {
-        super.setUpBeforeScenario()
-        print("Preparing before scenario")
+    func testCanSpecifyRegularTestAsWell() {
+        XCTAssert(true)
     }
 }

--- a/Example/Tests/Features/NativeFeatures/native_example_simple.feature
+++ b/Example/Tests/Features/NativeFeatures/native_example_simple.feature
@@ -1,6 +1,6 @@
 Feature: Simple Feature File Parsing
 
-    Scenario: This is a basic happy path example
+    Scenario: This is a very simple basic happy path example
         Given I have a working Gherkin environment
         Then this test should not fail
 

--- a/Pod/Native/NativeFeatureParser.swift
+++ b/Pod/Native/NativeFeatureParser.swift
@@ -1,0 +1,52 @@
+//
+//  NativeFeatureParser.swift
+//  Pods
+//
+//  Created by Marcin Raburski on 05/09/2016.
+//
+//
+
+import Foundation
+
+class NativeFeatureParser {
+    let path: NSURL
+    init(path: NSURL) {
+        self.path = path
+    }
+    
+    func parsedFeatures() -> [NativeFeature]? {
+        let manager = NSFileManager.defaultManager()
+        var isDirectory: ObjCBool = ObjCBool(false)
+        guard manager.fileExistsAtPath(self.path.path!, isDirectory: &isDirectory) else {
+            assertionFailure("The path doesn not exist '\(path)'")
+            return nil
+        }
+        
+        if isDirectory {
+            // Get the files from that folder
+            if let files = manager.enumeratorAtURL(path, includingPropertiesForKeys: nil, options: [], errorHandler: nil) {
+                return self.parseFeatureFiles(files)
+            } else {
+                assertionFailure("Could not open the path '\(path)'")
+            }
+            
+        } else {
+            if let feature = self.parseFeatureFile(path) {
+                return [feature]
+            }
+        }
+        return nil
+    }
+    
+    func parseFeatureFiles(files: NSDirectoryEnumerator) -> [NativeFeature] {
+        return files.map({ return self.parseFeatureFile($0 as! NSURL)!})
+    }
+    
+    func parseFeatureFile(file: NSURL) -> NativeFeature? {
+        guard let feature = NativeFeature(contentsOfURL:file, stepChecker:GherkinStepsChecker()) else {
+            assertionFailure("Could not parse feature at URL \(file.description)")
+            return nil
+        }
+        return feature
+    }
+}

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -46,7 +46,7 @@ public class NativeTestCase : XCTestCase {
             return testSuite
         }
         
-        guard let features = self.featuresForPath(path) else {
+        guard let features = NativeFeatureParser(path: path).parsedFeatures() else {
             assertionFailure("Could not retrieve features from the path '\(path)'")
             return testSuite
         }
@@ -67,43 +67,8 @@ public class NativeTestCase : XCTestCase {
             }
 
         }
-
+        
         return testSuite
     }
     
-    class func featuresForPath(path: NSURL) -> [NativeFeature]? {
-        let manager = NSFileManager.defaultManager()
-        var isDirectory: ObjCBool = ObjCBool(false)
-        guard manager.fileExistsAtPath(path.path!, isDirectory: &isDirectory) else {
-            XCTFail("The path doesn not exist '\(path)'")
-            return nil
-        }
-        
-        if isDirectory {
-            // Get the files from that folder
-            if let files = manager.enumeratorAtURL(path, includingPropertiesForKeys: nil, options: [], errorHandler: nil) {
-                return self.parseFeatureFiles(files)
-            } else {
-                XCTFail("Could not open the path '\(path)'")
-            }
-            
-        } else {
-            if let feature = self.parseFeatureFile(path) {
-                return [feature]
-            }
-        }
-        return nil
-    }
-    
-    class func parseFeatureFiles(files: NSDirectoryEnumerator) -> [NativeFeature] {
-        return files.map({ return self.parseFeatureFile($0 as! NSURL)!})
-    }
-    
-    class func parseFeatureFile(file: NSURL) -> NativeFeature? {
-        guard let feature = NativeFeature(contentsOfURL:file, stepChecker:GherkinStepsChecker()) else {
-            XCTFail("Could not parse feature at URL \(file.description)")
-            return nil
-        }
-        return feature
-    }
 }

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -13,33 +13,65 @@ import XCTest
 
 public class NativeTestCase : XCTestCase {
     
-    public var path:NSURL?
-    public func setUpBeforeScenario() {}
+    class public func path() -> NSURL? {
+        return nil
+    }
     
-    var testCaseClass: AnyClass!
+    internal var feature: NativeFeature?
+    internal var scenario: NativeScenario?
     
-    /**
-     This method will dynamically create tests from the files in the folder specified by setting the path property on this instance.
-    */
-    func testRunNativeTests() {
-        // If this hasn't been subclassed, just return
-        guard self.dynamicType != NativeTestCase.self else { return }
-        
-        // Sanity
-        guard let path = self.path else {
-            XCTAssertNotNil(self.path, "You must set the path for this test to run")
+    func featureScenarioTest() {
+        if self.state.stepChecker.shouldPrintTemplateCodeForAllMissingSteps() {
             return
+        }
+        
+        if let background = self.feature?.background {
+            background.stepDescriptions.forEach { self.performStep($0) }
+        }
+        if let scenario = self.scenario {
+            scenario.stepDescriptions.forEach { self.performStep($0) }
+        }
+    }
+    
+    override public class func defaultTestSuite() -> XCTestSuite {
+        let testSuite = XCTestSuite(name: NSStringFromClass(self))
+        
+        // This class must by subclassed in order to specify the path
+        guard self != NativeTestCase.self else {
+            return testSuite
+        }
+        
+        guard let path = self.path() else {
+            assertionFailure("You must set the path for this test to run")
+            return testSuite
         }
         
         guard let features = self.featuresForPath(path) else {
-            XCTFail("Could not retrieve features from the path '\(path)'")
-            return
+            assertionFailure("Could not retrieve features from the path '\(path)'")
+            return testSuite
         }
         
-        self.perform(features)
+        for feature in features {
+            for scenario in feature.scenarios {
+                
+                let selector = sel_registerName(scenario.selectorCString)
+                let method = class_getInstanceMethod(NativeTestCase.classForCoder(), #selector(featureScenarioTest))
+                let success = class_addMethod(NativeTestCase.classForCoder(), selector, method_getImplementation(method), method_getTypeEncoding(method))
+                
+                let testCase = super.init(selector: selector) as! NativeTestCase
+                
+                testCase.feature = feature
+                testCase.scenario = scenario
+            
+                testSuite.addTest(testCase)
+            }
+
+        }
+
+        return testSuite
     }
     
-    func featuresForPath(path: NSURL) -> [NativeFeature]? {
+    class func featuresForPath(path: NSURL) -> [NativeFeature]? {
         let manager = NSFileManager.defaultManager()
         var isDirectory: ObjCBool = ObjCBool(false)
         guard manager.fileExistsAtPath(path.path!, isDirectory: &isDirectory) else {
@@ -63,99 +95,15 @@ public class NativeTestCase : XCTestCase {
         return nil
     }
     
-    func parseFeatureFiles(files: NSDirectoryEnumerator) -> [NativeFeature] {
+    class func parseFeatureFiles(files: NSDirectoryEnumerator) -> [NativeFeature] {
         return files.map({ return self.parseFeatureFile($0 as! NSURL)!})
     }
     
-    func parseFeatureFile(file: NSURL) -> NativeFeature? {
-        guard let feature = NativeFeature(contentsOfURL:file, stepChecker:state.stepChecker) else {
+    class func parseFeatureFile(file: NSURL) -> NativeFeature? {
+        guard let feature = NativeFeature(contentsOfURL:file, stepChecker:GherkinStepsChecker()) else {
             XCTFail("Could not parse feature at URL \(file.description)")
             return nil
         }
         return feature
     }
-    
-    func perform(features: [NativeFeature]) {
-        if !state.stepChecker.shouldPrintTemplateCodeForAllMissingSteps() {
-            features.forEach({performFeature($0)})
-        }
-    }
-    
-    func performFeature(feature: NativeFeature) {
-        // Create a test case to contain our tests
-        let testClassName = "\(feature.featureDescription.camelCaseify)Tests"
-        
-        // If the class already exists means the feature could have been performed in other TestCases
-        if NSClassFromString(testClassName) != nil {
-            return
-        }
-        
-        let testCaseClassOptional:AnyClass? = objc_allocateClassPair(XCTestCase.self, testClassName, 0)
-        guard let testCaseClass = testCaseClassOptional else { XCTFail("Could not create test case class"); return }
-        self.testCaseClass = testCaseClass
-        
-        // Return the correct number of tests
-        let countBlock : @convention(block) (AnyObject) -> UInt = { _ in
-            return UInt(feature.scenarios.count)
-        }
-        let imp = imp_implementationWithBlock(unsafeBitCast(countBlock, AnyObject.self))
-        let sel = sel_registerName(strdup("testCaseCount"))
-        var success = class_addMethod(testCaseClass, sel, imp, strdup("I@:"))
-        XCTAssertTrue(success)
-        
-        // Return a name
-        let nameBlock : @convention(block) (AnyObject) -> String = { _ in
-            return feature.featureDescription.camelCaseify
-        }
-        let nameImp = imp_implementationWithBlock(unsafeBitCast(nameBlock, AnyObject.self))
-        let nameSel = sel_registerName(strdup("name"))
-        success = class_addMethod(testCaseClass, nameSel, nameImp, strdup("@@:"))
-        XCTAssertTrue(success)
-        
-        // Return a test run class - make it the same as the current run
-        let runBlock : @convention(block) (AnyObject) -> AnyObject! = { _ in
-            return self.testRun!.dynamicType
-        }
-        let runImp = imp_implementationWithBlock(unsafeBitCast(runBlock, AnyObject.self))
-        let runSel = sel_registerName(strdup("testRunClass"))
-        success = class_addMethod(testCaseClass, runSel, runImp, strdup("#@:"))
-        XCTAssertTrue(success)
-        
-        NSLog(feature.description)
-        
-        // For each scenario, make an invocation that runs through the steps
-        feature.scenarios.forEach { self.prepareScenarioInvocation($0, inFeature: feature) }
-        
-        // The test class is constructed, register it
-        objc_registerClassPair(testCaseClass)
-        
-        // Add the test to our test suite
-        testCaseClass.testInvocations().sort { (a,b) in NSStringFromSelector(a.selector) > NSStringFromSelector(b.selector) }.forEach { invocation in
-            let testCase = (testCaseClass as! XCTestCase.Type).init(invocation: invocation)
-            testCase.runTest()
-        }
-    }
-    
-    func prepareScenarioInvocation(scenario: NativeScenario, inFeature feature: NativeFeature) {
-        NSLog(scenario.description)
-        
-        // Create the block representing the test to be run
-        let block : @convention(block) (XCTestCase)->() = { innerSelf in
-            self.setUpBeforeScenario()
-            if let background = feature.background {
-                background.stepDescriptions.forEach { innerSelf.performStep($0) }
-            }
-            scenario.stepDescriptions.forEach { innerSelf.performStep($0) }
-        }
-        
-        // Create the Method and selector
-        let imp = imp_implementationWithBlock(unsafeBitCast(block, AnyObject.self))
-        let sel = sel_registerName(scenario.selectorCString)
-        
-        // Add this selector to ourselves
-        let typeString = strdup("v@:")
-        let success = class_addMethod(self.testCaseClass, sel, imp, typeString)
-        XCTAssertTrue(success, "Failed to add class method \(sel)")
-    }
-    
 }

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -55,8 +55,8 @@ public class NativeTestCase : XCTestCase {
             for scenario in feature.scenarios {
                 
                 let selector = sel_registerName(scenario.selectorCString)
-                let method = class_getInstanceMethod(NativeTestCase.classForCoder(), #selector(featureScenarioTest))
-                let success = class_addMethod(NativeTestCase.classForCoder(), selector, method_getImplementation(method), method_getTypeEncoding(method))
+                let method = class_getInstanceMethod(self, #selector(featureScenarioTest))
+                let success = class_addMethod(self, selector, method_getImplementation(method), method_getTypeEncoding(method))
                 
                 let testCase = super.init(selector: selector) as! NativeTestCase
                 

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -13,6 +13,12 @@ import XCTest
 
 public class NativeTestCase : XCTestCase {
     
+    // if you want to subclass this class without implementing any scenarios
+    // you can use this flag to skip path check
+    class public func shouldForcePathCheck() -> Bool {
+        return true
+    }
+    
     class public func path() -> NSURL? {
         return nil
     }
@@ -42,7 +48,9 @@ public class NativeTestCase : XCTestCase {
         }
         
         guard let path = self.path() else {
-            assertionFailure("You must set the path for this test to run")
+            if self.shouldForcePathCheck() {
+                assertionFailure("You must set the path for this test to run")
+            }
             return testSuite
         }
         


### PR DESCRIPTION
Hey guys,
I have refactored *NativeTestCase* so it can now support xcode-native setUp method for native scenarios. I believe the class itself became much cleaner. 
Additionally, file parsing was extracted to different class to separate concerns.
Merge will probably break your current NativeTestCase subclasses but IMO it's a change for the better. 
Hope you like it!