### PR TITLE
Removed unwrapped optional param from flatMap to fix Xcode 8.2 error

### DIFF
--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -45,7 +45,7 @@ class GherkinState {
             } else {
                 return nil
             }
-        }.flatMap { $0! }
+        }.flatMap { $0 }
         return matches
     }
     


### PR DESCRIPTION
flatMap take an array of optionals and return an array of unwrapped optionals without any nils so ! is unnecessary and Xcode 8.2 reports error