### PR TITLE
Add storage of the current step name 

### DIFF
--- a/Pod/Core/StringGherkinExtension.swift
+++ b/Pod/Core/StringGherkinExtension.swift
@@ -18,8 +18,7 @@ public extension String {
     */
     var camelCaseify: String {
         get {
-            guard case let c = (self.characters.split { $0 == " " || $0 == "-" })
-                , c.count > 1 else {
+            guard case let c = (self.characters.split { $0 == " " || $0 == "-" }), c.count > 1 else {
                 return self.uppercaseFirstLetterString
             }
             return c.map { String($0).lowercased().uppercaseFirstLetterString }
@@ -48,7 +47,7 @@ public extension String {
      */
     var humanReadableString: String {
         get {
-            guard case let c = self.characters , c.count > 1,
+            guard case let c = self.characters, c.count > 1,
                 let c1 = c.first else { return self }
             return String(c1) + c.dropFirst().reduce("") { (sum, c) in
                 let s = String(c)

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -35,6 +35,9 @@ class GherkinState {
     // Store the name of the current test to help debugging output
     var currentTestName:String = "NO TESTS RUN YET"
     
+    // Store the name of the current step to help debugging output
+    var currentStepName:String = "NO CURRENT STEP YET"
+    
     fileprivate var missingStepsImplementations = [String]()
     
     func gherkinStepsAndMatchesMatchingExpression(_ expression: String) -> [(step:Step, match:NSTextCheckingResult)] {
@@ -296,6 +299,7 @@ extension XCTestCase {
         // Debug the step name
         let coloredExpression = state.currentStepDepth == 0 ? ColorLog.green(expression) : ColorLog.lightGreen(expression)
         NSLog("step \(currentStepDepthString())\(coloredExpression)")
+        state.currentStepName = expression
         
         // Run the step
         state.currentStepDepth += 1

--- a/Pod/Native/NativeFeature.swift
+++ b/Pod/Native/NativeFeature.swift
@@ -61,7 +61,7 @@ extension NativeFeature {
         guard lines.count > 0 else { return nil }
         
         // The feature description needs to be on the first line - we'll fail this method if it isn't!
-        let (_,suffixOption) = lines.first!.componentsWithPrefix(FileTags.Feature)
+        let (_, suffixOption) = lines.first!.componentsWithPrefix(FileTags.Feature)
         guard let featureDescription = suffixOption else { return nil }
         
         let feature = NativeFeature.parseLines(lines)
@@ -85,7 +85,7 @@ extension NativeFeature {
         }
         
         // Go through each line in turn
-        for (lineIndex,line) in lines.enumerated() {
+        for (lineIndex, line) in lines.enumerated() {
             
             if !line.isEmpty {
                 // What kind of line is it?
@@ -141,7 +141,7 @@ private let whitespace = CharacterSet.whitespaces
 extension String {
     
     func componentsWithPrefix(_ prefix: String) -> (String, String?) {
-        guard self.hasPrefix(prefix) else { return (self,nil) }
+        guard self.hasPrefix(prefix) else { return (self, nil) }
         
         let index = (prefix as NSString).length
         let suffix = (self as NSString).substring(from: index).trimmingCharacters(in: whitespace)

--- a/Pod/Native/ParseState.swift
+++ b/Pod/Native/ParseState.swift
@@ -58,13 +58,13 @@ class ParseState {
     }
     
     func background() -> NativeBackground? {
-        guard parsingBackground, let description = self.description , self.steps.count > 0 else { return nil }
+        guard parsingBackground, let description = self.description, self.steps.count > 0 else { return nil }
         
         return NativeBackground(description, steps: self.steps)
     }
     
     func scenarios() -> [NativeScenario]? {
-        guard let description = self.description , self.steps.count > 0 else { return nil }
+        guard let description = self.description, self.steps.count > 0 else { return nil }
         
         var scenarios = Array<NativeScenario>()
         


### PR DESCRIPTION
Add storage of the current step name and some minor code formatting changes.

Storage of the current step name helps us to get clearer logging on our Jenkins CI.