### PR TITLE
Update CocoaPods version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: objective-c
 osx_image: xcode8
 
 before_install:
-  - gem install cocoapods --version 1.1.0.rc2
+  - gem install cocoapods --version 1.2.0
 
 env:
   - DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=9.1' UI=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # XCTest-Gherkin changelog
 
 ### Unreleased
++ Update CocoaPods version in .travis.yml to 1.2.0
 
 ## 0.9
 + Fix for Xcode 8.2


### PR DESCRIPTION
CocoaPods 1.2.0 is the latest version of CocoaPods. Based on the `Podfile.lock` in the example project, we're using CocoaPods 1.2.0 (https://github.com/net-a-porter-mobile/XCTest-Gherkin/blob/master/Example/Podfile.lock#L18). Makes sense to update the Travis version too.