### PR TITLE
Update to iOS 10.3 simulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ before_install:
 
 env:
   - DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=9.1' UI=true
-  - DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=10.0' UI=true
+  - DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=10.3' UI=true
   - DESTINATION='platform=iOS Simulator,name=iPad Air,OS=9.1' UI=true
-  - DESTINATION='platform=iOS Simulator,name=iPad Air,OS=10.0' UI=true
+  - DESTINATION='platform=iOS Simulator,name=iPad Air,OS=10.3' UI=true
 
 script:
 - set -o pipefail


### PR DESCRIPTION
I've noticed that since we updated to Xcode 8.3, Travis is timing out a lot more often (error code 65) on builds in latest iOS. It seems to be a recurring issue: https://github.com/travis-ci/travis-ci/issues/6675. I'm hoping this will help. If it doesn't, we might have to think about other ways of palliating these symptoms: https://github.com/travis-ci/travis-ci/issues/6675#issuecomment-282041416 and creating a radar: https://github.com/travis-ci/travis-ci/issues/6675#issuecomment-261757936 and include:

Tarball from `sudo sysdiagnose -q`
Contents of `~/Library/Logs/CoreSimulator`
xcactivity logs from the test run in `~/Library/Developer/Xcode/DerivedData/<project>/Logs`