### PR TITLE
Revert "Replace initialize class method"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
 - travis/validate_carthage.sh
 - xcodebuild -destination "$DESTINATION" -workspace Example/XCTest-Gherkin.xcworkspace -scheme XCTest-Gherkin-Example -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO test | xcpretty
 - if [ $UI ]; then xcodebuild -destination "$DESTINATION" -workspace Example/XCTest-Gherkin.xcworkspace -scheme XCTest-Gherkin-Example-UI -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO test | xcpretty; fi
-- pod lib lint
+- pod lib lint --allow-warnings

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -13,11 +13,19 @@ import XCTest
 
 open class NativeTestCase: XCTestCase {
     
-    static let initialize: Void = {
-        for feature in NativeTestCase.features() {
-            feature.scenarios.forEach(NativeTestCase.registerTestMethod)
+    open override class func initialize() {
+        super.initialize()
+        
+        // This class must by subclassed in order to specify the path
+        guard self != NativeTestCase.self else {
+            return
         }
-    }()
+        
+        // Register all the scenario test methods for defined features
+        for feature in self.features() {
+            feature.scenarios.forEach(self.registerTestMethod)
+        }
+    }
     
     // MARK: Config and properties
     


### PR DESCRIPTION
This reverts commit f7d59064fe20006077a378b3a1876e8711438e23.

Turns out I'm an idiot (not news for some) -- this reverts the change to remove the `open override class func initialize()` and replace it with a `static let` (which are lazily initialized). Also the effects of the change were completely different than I thought they were, so there's that.

I think @smaljaar's suggestion (https://github.com/net-a-porter-mobile/XCTest-Gherkin/issues/66) of removing NativeTestCase and replacing it with the `NativeRunner` makes sense, and, IMO, makes the public API slightly easier to understand.