### PR TITLE
Feature/xcode9 use xcactivity to improve native logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 + Clearer failure message when step isn't found
 + Allow Double and Bool as closure types in step definitions
 + Allow mix of closure parameter types in step definitions with two matches
++ Wrap execution of each step in XCTContext's runActivity method so we get better logging within Xcode of native Gherkin.
 
 ### 0.10.2
 + Update .travis.yml to Xcode 8.3

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -252,8 +252,8 @@ extension XCTestCase {
      Finds and performs a step test based on expression
      */
     func performStep(_ initialExpression: String) {
-        
-        XCTContext.runActivity(named: initialExpression) { (activity) in
+
+        func perform(expression: String) {
             
             // Get a mutable copy - if we are in an outline we might be changing this
             var expression = initialExpression
@@ -308,6 +308,14 @@ extension XCTestCase {
             step.function(matchStrings)
             state.currentStepDepth -= 1
         }
+        
+        #if swift(>=4)
+            XCTContext.runActivity(named: initialExpression) { (_) in
+                perform(expression: initialExpression)
+            }
+        #else
+        perform(expression: initialExpression)
+        #endif
     }
     
     /**

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -252,58 +252,62 @@ extension XCTestCase {
      Finds and performs a step test based on expression
      */
     func performStep(_ initialExpression: String) {
-        // Get a mutable copy - if we are in an outline we might be changing this
-        var expression = initialExpression
         
-        // Make sure that we have created our steps
-        self.state.loadAllStepsIfNeeded()
-        
-        // If we are in an example, transform the step to reflect the current example's value
-        if let example = state.currentExample {
-            // For each field in the example, go through the step expression and replace the placeholders if needed
-            example.forEach { (key, value) in
-                let needle = "<\(key)>"
-                expression = (expression as NSString).replacingOccurrences(of: needle, with: value)
+        XCTContext.runActivity(named: initialExpression) { (activity) in
+            
+            // Get a mutable copy - if we are in an outline we might be changing this
+            var expression = initialExpression
+            
+            // Make sure that we have created our steps
+            self.state.loadAllStepsIfNeeded()
+            
+            // If we are in an example, transform the step to reflect the current example's value
+            if let example = state.currentExample {
+                // For each field in the example, go through the step expression and replace the placeholders if needed
+                example.forEach { (key, value) in
+                    let needle = "<\(key)>"
+                    expression = (expression as NSString).replacingOccurrences(of: needle, with: value)
+                }
             }
-        }
-        
-        // Get the step and the matches inside it
-        guard let (step, match) = self.state.gherkinStepsAndMatchesMatchingExpression(expression).first else {
-            if !self.state.matchingGherkinStepExpressionFound(expression) && self.state.shouldPrintTemplateCodeForAllMissingSteps() {
-                self.state.printStepDefinitions()
-                self.state.printTemplatedCodeForAllMissingSteps()
-                self.state.resetMissingSteps()
+            
+            // Get the step and the matches inside it
+            guard let (step, match) = self.state.gherkinStepsAndMatchesMatchingExpression(expression).first else {
+                if !self.state.matchingGherkinStepExpressionFound(expression) && self.state.shouldPrintTemplateCodeForAllMissingSteps() {
+                    self.state.printStepDefinitions()
+                    self.state.printTemplatedCodeForAllMissingSteps()
+                    self.state.resetMissingSteps()
+                }
+                fatalError("Failed to find a match for a step: \(expression)")
             }
-            fatalError("Failed to find a match for a step: \(expression)")
-        }
-        
-        // Covert them to strings to pass back into the step function
-        // TODO: This should really only need to be a map function :(
-        var matchStrings = Array<String>()
-        for i in 1..<match.numberOfRanges {
-            let range = match.rangeAt(i)
-            let string = range.location != NSNotFound ? (expression as NSString).substring(with: range) : ""
-            matchStrings.append(string)
-        }
-        
-        // If this the first step, debug the test name as well
-        if state.currentStepDepth == 0 {
-            let rawName = String(describing: self.invocation!.selector)
-            let testName = rawName.hasPrefix("test") ? (rawName as NSString).substring(from: 4) : rawName
-            if testName != state.currentTestName {
-                NSLog("steps from \(testName.humanReadableString)")
-                state.currentTestName = testName
+            
+            // Covert them to strings to pass back into the step function
+            // TODO: This should really only need to be a map function :(
+            var matchStrings = Array<String>()
+            for i in 1..<match.numberOfRanges {
+                let range = match.rangeAt(i)
+                let string = range.location != NSNotFound ? (expression as NSString).substring(with: range) : ""
+                matchStrings.append(string)
             }
+            
+            // If this the first step, debug the test name as well
+            if state.currentStepDepth == 0 {
+                let rawName = String(describing: self.invocation!.selector)
+                let testName = rawName.hasPrefix("test") ? (rawName as NSString).substring(from: 4) : rawName
+                if testName != state.currentTestName {
+                    NSLog("steps from \(testName.humanReadableString)")
+                    state.currentTestName = testName
+                }
+            }
+            
+            // Debug the step name
+            NSLog("step \(currentStepDepthString())\(expression)")
+            state.currentStepName = expression
+            
+            // Run the step
+            state.currentStepDepth += 1
+            step.function(matchStrings)
+            state.currentStepDepth -= 1
         }
-        
-        // Debug the step name
-        NSLog("step \(currentStepDepthString())\(expression)")
-        state.currentStepName = expression
-        
-        // Run the step
-        state.currentStepDepth += 1
-        step.function(matchStrings)
-        state.currentStepDepth -= 1
     }
     
     /**

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -309,6 +309,7 @@ extension XCTestCase {
             state.currentStepDepth -= 1
         }
         
+        //TODO: remove this check once we are migrated to Swift 4
         #if swift(>=4)
             XCTContext.runActivity(named: initialExpression) { (_) in
                 perform(expression: initialExpression)

--- a/Pod/Native/NativeRunner.swift
+++ b/Pod/Native/NativeRunner.swift
@@ -32,7 +32,7 @@ open class NativeRunner {
             }
             
             for scenario in scenarios {
-                NativeTestCase.perform(scenario: scenario, from: feature, in: testCase)
+                testCase.perform(scenario: scenario, from: feature)
             }
         }
     }

--- a/Pod/Native/NativeRunner.swift
+++ b/Pod/Native/NativeRunner.swift
@@ -37,11 +37,9 @@ open class NativeRunner {
         }
     }
     
-    
     public class func runFeature(featureFile: String, testCase: XCTestCase) {
         NativeRunner.runScenario(featureFile: featureFile, scenario: nil, testCase: testCase)
     }
-
     
     private class func loadFeatures(path : URL) -> [NativeFeature] {
         guard let features = NativeFeatureParser(path: path).parsedFeatures() else {
@@ -51,5 +49,4 @@ open class NativeRunner {
         
         return features
     }
-
 }

--- a/Pod/Native/NativeRunner.swift
+++ b/Pod/Native/NativeRunner.swift
@@ -32,22 +32,7 @@ open class NativeRunner {
             }
             
             for scenario in scenarios {
-                let allScenarioStepsDefined = scenario.stepDescriptions.map(testCase.state.matchingGherkinStepExpressionFound).reduce(true) { $0 && $1 }
-                var allFeatureBackgroundStepsDefined = true
-                
-                if let defined = feature.background?.stepDescriptions.map(testCase.state.matchingGherkinStepExpressionFound).reduce(true, { $0 && $1 }) {
-                    allFeatureBackgroundStepsDefined = defined
-                }
-                
-                guard allScenarioStepsDefined && allFeatureBackgroundStepsDefined else {
-                    XCTFail("Some step definitions not found for the scenario: \(scenario.scenarioDescription)")
-                    return
-                }
-                
-                if let background = feature.background {
-                    background.stepDescriptions.forEach(testCase.performStep)
-                }
-                scenario.stepDescriptions.forEach(testCase.performStep)
+                NativeTestCase.perform(scenario: scenario, from: feature, in: testCase)
             }
         }
     }

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -97,9 +97,17 @@ open class NativeTestCase: XCTestCase {
         }
         
         if let background = feature.background {
-            background.stepDescriptions.forEach(self.performStep)
+            background.stepDescriptions.forEach { (stepDescription: String) in
+                XCTContext.runActivity(named: stepDescription, block: { (activity) in
+                    self.performStep(stepDescription)
+                })
+            }
         }
-        scenario.stepDescriptions.forEach(self.performStep)
+        scenario.stepDescriptions.forEach { (stepDescription: String) in
+            XCTContext.runActivity(named: stepDescription, block: { (activity) in
+                self.performStep(stepDescription)
+            })
+        }
     }
     
     // MARK: Auxiliary

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -83,30 +83,11 @@ open class NativeTestCase: XCTestCase {
         guard let (feature, scenario) = type(of: self).featureScenarioData(self.invocation!.selector) else {
             return
         }
-        NativeTestCase.perform(scenario: scenario, from: feature, in: self)
+        perform(scenario: scenario, from: feature)
     }
     
     // MARK: Auxiliary
-    class func perform(scenario: NativeScenario, from feature: NativeFeature, in testCase: XCTestCase) {
-        let allScenarioStepsDefined = scenario.stepDescriptions.map(testCase.state.matchingGherkinStepExpressionFound).reduce(true) { $0 && $1 }
-        var allFeatureBackgroundStepsDefined = true
-        
-        if let defined = feature.background?.stepDescriptions.map(testCase.state.matchingGherkinStepExpressionFound).reduce(true, { $0 && $1 }) {
-            allFeatureBackgroundStepsDefined = defined
-        }
-        
-        guard allScenarioStepsDefined && allFeatureBackgroundStepsDefined else {
-            XCTFail("Some step definitions not found for the scenario: \(scenario.scenarioDescription)")
-            return
-        }
-        
-        if let background = feature.background {
-            background.stepDescriptions.forEach(testCase.performStep)
-        }
-        scenario.stepDescriptions.forEach(testCase.performStep)
-    }
-    
-    
+
     class func featureScenarioData(_ forSelector: Selector) -> (NativeFeature, NativeScenario)? {
         for feature in self.features() {
             if let scenario = feature.scenarios.filter({ $0.selectorString == NSStringFromSelector(forSelector) }).first {
@@ -123,4 +104,25 @@ open class NativeTestCase: XCTestCase {
         assert(success, "Could not swizzle feature test method!")
     }
     
+}
+
+extension XCTestCase {
+    func perform(scenario: NativeScenario, from feature: NativeFeature) {
+        let allScenarioStepsDefined = scenario.stepDescriptions.map(state.matchingGherkinStepExpressionFound).reduce(true) { $0 && $1 }
+        var allFeatureBackgroundStepsDefined = true
+        
+        if let defined = feature.background?.stepDescriptions.map(state.matchingGherkinStepExpressionFound).reduce(true, { $0 && $1 }) {
+            allFeatureBackgroundStepsDefined = defined
+        }
+        
+        guard allScenarioStepsDefined && allFeatureBackgroundStepsDefined else {
+            XCTFail("Some step definitions not found for the scenario: \(scenario.scenarioDescription)")
+            return
+        }
+        
+        if let background = feature.background {
+            background.stepDescriptions.forEach(self.performStep)
+        }
+        scenario.stepDescriptions.forEach(self.performStep)
+    }
 }


### PR DESCRIPTION
This is the implementation as discussed in https://github.com/net-a-porter-mobile/XCTest-Gherkin/issues/70 

For backward compatibility with Xcode 8 I added a swift(>=4) check to include/exclude the use of the new XCContext.runActivity API.

@nap-sam-dean @kerrmarin 