### PR TITLE
Travis xcode 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ script:
 
 matrix:
   include:
-    - osx_image: xcode8
+    - osx_image: xcode8.3
       env: DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=10.3.1' UI=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,9 @@ script:
 - xcodebuild -destination "$DESTINATION" -workspace Example/XCTest-Gherkin.xcworkspace -scheme XCTest-Gherkin-Example -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO test | xcpretty
 - if [ $UI ]; then xcodebuild -destination "$DESTINATION" -workspace Example/XCTest-Gherkin.xcworkspace -scheme XCTest-Gherkin-Example-UI -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO test | xcpretty; fi
 - pod lib lint --allow-warnings
+
+
+matrix:
+  include:
+    - osx_image: xcode8
+      env: DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=10.3.1' UI=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ before_install:
 env:
   - DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=11.0' UI=true
   - DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=10.3.1' UI=true
-  - DESTINATION='platform=iOS Simulator,name=iPad Air,OS=11.0' UI=true
-  - DESTINATION='platform=iOS Simulator,name=iPad Air,OS=10.3.1' UI=true
 
 script:
 - set -o pipefail

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@
 # * https://github.com/supermarin/xcpretty#usage
 
 language: objective-c
-osx_image: xcode8.3
+osx_image: xcode9
 
 before_install:
   - gem install cocoapods --version 1.2.0
 
 env:
-  - DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=9.1' UI=true
+  - DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=11.0' UI=true
   - DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=10.3.1' UI=true
-  - DESTINATION='platform=iOS Simulator,name=iPad Air,OS=9.1' UI=true
+  - DESTINATION='platform=iOS Simulator,name=iPad Air,OS=11.0' UI=true
   - DESTINATION='platform=iOS Simulator,name=iPad Air,OS=10.3.1' UI=true
 
 script:

--- a/Pod/Core/ClassHelperMethods.swift
+++ b/Pod/Core/ClassHelperMethods.swift
@@ -44,13 +44,21 @@ fileprivate func class_getRootSuperclass(_ type: AnyObject.Type) -> AnyObject.Ty
 }
 
 fileprivate func allClasses() -> [AnyClass] {
+    // Get an approximate amount of classes we are going to need space for.
+    // Double it, just to make sure if it returns more we can still accomodate them all
     let expectedClassCount = objc_getClassList(nil, 0) * 2
+
     let allClasses = UnsafeMutablePointer<AnyClass?>.allocate(capacity: Int(expectedClassCount))
     let autoreleasingAllClasses = AutoreleasingUnsafeMutablePointer<AnyClass?>(allClasses)  // Huh? We should have gotten this for free.
     let actualClassCount = objc_getClassList(autoreleasingAllClasses, expectedClassCount)
 
+    // Take care of the stunningly rare situation where we get more classes back than we have allocated,
+    // remembering that we have allocated more than we were told to, to take case of the unexpected case
+    // where we recieve more classes than we were told we were going to three lines previously. #paranoid #safe
+    let count = min(actualClassCount, expectedClassCount)
+
     var classes = [AnyClass]()
-    for i in 0 ..< actualClassCount {
+    for i in 0 ..< count {
         if let currentClass: AnyClass = allClasses[Int(i)] {
             classes.append(currentClass)
         }


### PR DESCRIPTION
Subtle, and very annoying, bug in `allSubclassesOf`.

If the initial call to objc_getClassList returned fewer classes than were returned from the second call then the buffer was filled to the correct limit (bug 1 - some classes might get randomly missed out) but the loop went from 0 to the larger amount (bug 2 - buffer overrun).

Fixed by allocating the buffer to twice the expected amount. Not that fussed by the inefficiency here, it's deallocated almost immediately afterwards, and isn't going to be a _vast_ allocation anyway.

I've also updated the travis file to work with the Xcode 9 image, with a single job still running xcode 8 until we decide to drop support for it.