### PR TITLE
Update README and add test to show start/end regex anchors removing ambiguity.

### DIFF
--- a/Example/Tests/Features/ExampleFeatures.swift
+++ b/Example/Tests/Features/ExampleFeatures.swift
@@ -77,4 +77,8 @@ final class ExampleFeatures: XCTestCase {
         And("I have a double which looks like an int 1")
         And("I have a mixture of types 1.1 hello")
     }
+
+    func testStepAnchorMatching() {
+        Given("This is a substring")
+    }
 }

--- a/Example/Tests/StepDefinitions/SanitySteps.swift
+++ b/Example/Tests/StepDefinitions/SanitySteps.swift
@@ -114,5 +114,13 @@ final class SanitySteps: StepDefiner {
             XCTAssertEqual(d, 1.1)
             XCTAssertEqual(s, "hello")
         }
+
+        step("^a substring$") {
+            XCTFail("This step shouldn't match")
+        }
+
+        step("This is a substring") {
+            // This step should match instead of the one above, even though the other one is defined first
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -121,6 +121,31 @@ steps
 XCTestCase+Gherkin.swift:165: error: -[XCTest_Gherkin_Tests.ExampleFeatures testBasicSteps] : failed - Step definition not found for 'I have a working Pickle environment'
 ```
 
+#### Ambiguous steps
+
+Sometimes, multiple steps might contain the same text. The library will match with what it thinks is the right step, but it might get it wrong. For example if you have these step definitions:
+
+```
+step("email button") { ... }
+step("I tap the email button") { ... }
+```
+
+When you try to run this Given
+```
+func testStepAnchorMatching() {
+    Given("I tap the email button")
+}
+```
+
+it might match against the "email button" step, instead of the "I tap the email button" step. To fix this, you can anchor the regular expression to the start and end of the string using `^` and `$`, like this:
+
+```
+step("^email button$") { ... }
+step("I tap the email button") { ... }
+```
+
+Now, "I tap the email button" doesn't match the first step.
+
 ## Installation
 
 ### CocoaPods

--- a/README.md
+++ b/README.md
@@ -96,14 +96,6 @@ NB The examples have to be defined _before_ the `Outline {..}` whereas in Gherki
 
 ### Dealing with errors / debugging tests
 
-#### Duplicate steps:
-
-If there are step definitions which all match a step in your feature then the test will fail with an error something like 
-
-```
--[XCTest_Gherkin_Tests.ExampleFeatures testBasicSteps] : failed - Multiple steps found for : I have a working Gherkin environment
-```
-
 #### Missing steps
 
 If there isn't a step definition found for a step in your feature file then the extensions will output a list of all the available steps and then fail the test, something like:


### PR DESCRIPTION
As discussed in #95 