### PR TITLE
Record additional failures in steps

### DIFF
--- a/Pod/Core/StepDefiner.swift
+++ b/Pod/Core/StepDefiner.swift
@@ -15,16 +15,6 @@ populate the step definitions before test runs
 open class StepDefiner: NSObject, XCTestObservation {
     public private(set) var test: XCTestCase
 
-    // file from where the step was invoked
-    public var file: StaticString {
-        return test.state.file
-    }
-
-    // line from where the step was invoked
-    public var line: UInt {
-        return test.state.line
-    }
-
     required public init(test: XCTestCase) {
         self.test = test
 

--- a/Pod/Core/StepDefiner.swift
+++ b/Pod/Core/StepDefiner.swift
@@ -15,6 +15,16 @@ populate the step definitions before test runs
 open class StepDefiner: NSObject, XCTestObservation {
     public private(set) var test: XCTestCase
 
+    // file from where the step was invoked
+    public var file: StaticString {
+        return test.state.file
+    }
+
+    // line from where the step was invoked
+    public var line: UInt {
+        return test.state.line
+    }
+
     required public init(test: XCTestCase) {
         self.test = test
 

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -17,7 +17,7 @@ UITestCase - a subclass wouldn't work with both of them.
 It's nicer code IMHO to have the state as a single associated property beacuse of the grossness of setting/getting it.
 This means that anytime I want to access my extra properties I just do `state.{propertyName}`
 */
-class GherkinState {
+class GherkinState: NSObject, XCTestObservation {
     var test: XCTestCase?
     
     // The list of all steps the system knows about
@@ -26,6 +26,12 @@ class GherkinState {
     // Used to track step nesting i.e. steps calling out to other steps
     var currentStepDepth: Int = 0
     
+    // file from where currently executed step was invoked
+    var file: StaticString!
+
+    // line from where currently executed step was invoked
+    var line: UInt!
+
     // When we are in an Outline block, this defines the examples to loop over
     var examples: [Example]?
     
@@ -40,6 +46,23 @@ class GherkinState {
     
     fileprivate var missingStepsImplementations = [String]()
     
+    override init() {
+        super.init()
+        XCTestObservationCenter.shared.addTestObserver(self)
+    }
+
+    deinit {
+        XCTestObservationCenter.shared.removeTestObserver(self)
+    }
+
+    func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
+        guard let test = self.test else { return }
+        let file = "\(test.state.file!)"
+        let line = Int(test.state.line)
+        guard filePath != file, lineNumber != line else { return }
+        test.recordFailure(withDescription: description, inFile: file, atLine: line, expected: false)
+    }
+
     func gherkinStepsAndMatchesMatchingExpression(_ expression: String) -> [(step: Step, match: NSTextCheckingResult)] {
         let range = NSMakeRange(0, expression.count)
 
@@ -140,22 +163,22 @@ public extension XCTestCase {
     /**
      Run the step matching the specified expression
      */
-    func Given(_ expression: String) { self.performStep(expression) }
+    func Given(_ expression: String, file: StaticString = #file, line: UInt = #line) { self.performStep(expression, file: file, line: line) }
     
     /**
      Run the step matching the specified expression
      */
-    func When(_ expression: String) { self.performStep(expression) }
+    func When(_ expression: String, file: StaticString = #file, line: UInt = #line) { self.performStep(expression, file: file, line: line) }
     
     /**
      Run the step matching the specified expression
      */
-    func Then(_ expression: String) { self.performStep(expression) }
+    func Then(_ expression: String, file: StaticString = #file, line: UInt = #line) { self.performStep(expression, file: file, line: line) }
     
     /**
      Run the step matching the specified expression
      */
-    func And(_ expression: String) { self.performStep(expression) }
+    func And(_ expression: String, file: StaticString = #file, line: UInt = #line) { self.performStep(expression, file: file, line: line) }
     
     /**
      Supply a set of example data to the test. This must be done before calling `Outline`.
@@ -247,7 +270,7 @@ extension XCTestCase {
     /**
      Finds and performs a step test based on expression
      */
-    func performStep(_ initialExpression: String) {
+    func performStep(_ initialExpression: String, file: StaticString = #file, line: UInt = #line) {
 
         func perform(expression: String) {
             
@@ -301,8 +324,12 @@ extension XCTestCase {
             
             // Run the step
             state.currentStepDepth += 1
+            state.file = file
+            state.line = line
             step.function(matchStrings)
             state.currentStepDepth -= 1
+            state.file = nil
+            state.line = nil
         }
         
         XCTContext.runActivity(named: initialExpression) { (_) in

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -121,8 +121,8 @@ extension XCTestCase {
         }
         
         if let background = feature.background {
-            background.stepDescriptions.forEach(self.performStep)
+            background.stepDescriptions.forEach({ self.performStep($0) })
         }
-        scenario.stepDescriptions.forEach(self.performStep)
+        scenario.stepDescriptions.forEach({ self.performStep($0) })
     }
 }


### PR DESCRIPTION
It's inconvenient when a test step fails to see failures only where the failure actually happened and not in which step of test it happened. With this change currently executed step, location is stored in state and when failure happens additional failure is recorded at the same location. This way it will be visible what step failed and what exact assert down the way caused it.

Failure in feature file:
<img width="420" alt="screen shot 2018-08-02 at 20 40 15" src="https://user-images.githubusercontent.com/1488293/43606870-7b77d0ea-9694-11e8-9fc4-b2020af342cd.png">

Failure in steps definer:
<img width="607" alt="screen shot 2018-08-02 at 20 42 35" src="https://user-images.githubusercontent.com/1488293/43606934-a1379a18-9694-11e8-8d6a-808a076570f2.png">
