### PR TITLE
Allow automatic screenshots before/after steps and on failures

### DIFF
--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -282,6 +282,9 @@ extension XCTestCase {
     }
 
     func attachScreenshot(name: String) {
+        // if tests have no host app there is no point in making screenshots
+        guard Bundle.main.bundlePath.hasSuffix(".app") else { return }
+
         let screenshot = XCUIScreen.main.screenshot()
         let attachment = XCTAttachment(screenshot: screenshot, quality: automaticScreenshotsQuality)
         attachment.name = name

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -58,6 +58,10 @@ class GherkinState: NSObject, XCTestObservation {
         let line = Int(currentStepLocation.line)
         guard filePath != file, lineNumber != line else { return }
         test.recordFailure(withDescription: description, inFile: file, atLine: line, expected: false)
+
+        if automaticScreenshotsBehaviour.contains(.onFailure) {
+            test.attachScreenshot(name: "Failed \"\(currentStepName)\"")
+        }
     }
 
     func gherkinStepsAndMatchesMatchingExpression(_ expression: String) -> [(step: Step, match: NSTextCheckingResult)] {
@@ -250,6 +254,32 @@ public extension XCTestCase {
     
 }
 
+private var automaticScreenshotsBehaviour: AutomaticScreenshotsBehaviour = []
+
+public struct AutomaticScreenshotsBehaviour: OptionSet {
+    public let rawValue: Int
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    public static let onFailure    = AutomaticScreenshotsBehaviour(rawValue: 1 << 0)
+    public static let beforeStep   = AutomaticScreenshotsBehaviour(rawValue: 1 << 1)
+    public static let afterStep    = AutomaticScreenshotsBehaviour(rawValue: 1 << 2)
+}
+
+extension XCTestCase {
+    public static func setAutomaticScreenshotsBehaviour(_ behaviour: AutomaticScreenshotsBehaviour) {
+        automaticScreenshotsBehaviour = behaviour
+    }
+
+    func attachScreenshot(name: String) {
+        let screenshot = XCUIScreen.main.screenshot()
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = name
+        add(attachment)
+    }
+}
+
 /**
  Put our package methods into this extension
 */
@@ -322,7 +352,13 @@ extension XCTestCase {
             // Run the step
             state.currentStepDepth += 1
             state.currentStepLocation = (file, line)
+            if automaticScreenshotsBehaviour.contains(.beforeStep) {
+                attachScreenshot(name: "Before \"\(expression)\"")
+            }
             step.function(matchStrings)
+            if automaticScreenshotsBehaviour.contains(.afterStep) {
+                attachScreenshot(name: "After \"\(expression)\"")
+            }
             state.currentStepLocation = nil
             state.currentStepDepth -= 1
         }

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -268,6 +268,7 @@ public struct AutomaticScreenshotsBehaviour: OptionSet {
     public static let beforeStep    = AutomaticScreenshotsBehaviour(rawValue: 1 << 1)
     public static let afterStep     = AutomaticScreenshotsBehaviour(rawValue: 1 << 2)
     public static let none: AutomaticScreenshotsBehaviour = []
+    public static let all: AutomaticScreenshotsBehaviour = [.onFailure, .beforeStep, .afterStep]
 }
 
 extension XCTestCase {

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -254,7 +254,9 @@ public extension XCTestCase {
     
 }
 
-private var automaticScreenshotsBehaviour: AutomaticScreenshotsBehaviour = []
+private var automaticScreenshotsBehaviour: AutomaticScreenshotsBehaviour = .none
+private var automaticScreenshotsQuality: XCTAttachment.ImageQuality = .medium
+private var automaticScreenshotsLifetime: XCTAttachment.Lifetime = .deleteOnSuccess
 
 public struct AutomaticScreenshotsBehaviour: OptionSet {
     public let rawValue: Int
@@ -262,20 +264,28 @@ public struct AutomaticScreenshotsBehaviour: OptionSet {
         self.rawValue = rawValue
     }
 
-    public static let onFailure    = AutomaticScreenshotsBehaviour(rawValue: 1 << 0)
-    public static let beforeStep   = AutomaticScreenshotsBehaviour(rawValue: 1 << 1)
-    public static let afterStep    = AutomaticScreenshotsBehaviour(rawValue: 1 << 2)
+    public static let onFailure     = AutomaticScreenshotsBehaviour(rawValue: 1 << 0)
+    public static let beforeStep    = AutomaticScreenshotsBehaviour(rawValue: 1 << 1)
+    public static let afterStep     = AutomaticScreenshotsBehaviour(rawValue: 1 << 2)
+    public static let none: AutomaticScreenshotsBehaviour = []
 }
 
 extension XCTestCase {
-    public static func setAutomaticScreenshotsBehaviour(_ behaviour: AutomaticScreenshotsBehaviour) {
+
+    /// Set behaviour for automatic screenshots (default is `.none`), their quality (default is `.medium`) and lifetime (default is `.deleteOnSuccess`)
+    public static func setAutomaticScreenshotsBehaviour(_ behaviour: AutomaticScreenshotsBehaviour,
+                                                        quality: XCTAttachment.ImageQuality = .medium,
+                                                        lifetime: XCTAttachment.Lifetime = .deleteOnSuccess) {
         automaticScreenshotsBehaviour = behaviour
+        automaticScreenshotsQuality = quality
+        automaticScreenshotsLifetime = lifetime
     }
 
     func attachScreenshot(name: String) {
         let screenshot = XCUIScreen.main.screenshot()
-        let attachment = XCTAttachment(screenshot: screenshot)
+        let attachment = XCTAttachment(screenshot: screenshot, quality: automaticScreenshotsQuality)
         attachment.name = name
+        attachment.lifetime = automaticScreenshotsLifetime
         add(attachment)
     }
 }


### PR DESCRIPTION
Xcode can make automatic screenshots which is very helpful when investigating test failures, but there is no way to control this behavior and it creates a lot of redundant screenshots, i.e. it can create a dozen screenshots just while launching the app (14 in my case, but I guess it can depend on how long it takes to load the app). When running UI tests on cloud CI, i.e. CircleCI that results in a dramatic performance hit when uploading test results. For 17 failed tests it generated more than 3000 screenshots making the size of test results bundle more than 1 GB and adding almost 30 minutes to test runtime to upload these artifacts.

Currently, we are making screenshots manually in a `tearDown` of a base test case class, but that will only leave us a single screenshot which might not be enough to originate the issue.

With this change, it will be possible to configure automatic screenshots to be done before/after a step or on each failure. This will still produce duplicated images, but much less and gives more control over them with lifetime and quality and will allow extending this behavior to make it smarter in future (avoid making duplicates).