### PR TITLE
Introduce CodableMatchedStringRepresentable protocol

### DIFF
--- a/Example/Tests/Features/ExampleFeatures.swift
+++ b/Example/Tests/Features/ExampleFeatures.swift
@@ -81,4 +81,9 @@ final class ExampleFeatures: XCTestCase {
     func testStepAnchorMatching() {
         Given("This is a substring")
     }
+
+    func testCodableMatches() {
+        let person = Person(name: "Nick")
+        Given("This is Nick \(person)")
+    }
 }

--- a/Example/Tests/StepDefinitions/SanitySteps.swift
+++ b/Example/Tests/StepDefinitions/SanitySteps.swift
@@ -122,5 +122,13 @@ final class SanitySteps: StepDefiner {
         step("This is a substring") {
             // This step should match instead of the one above, even though the other one is defined first
         }
+
+        step("This is Nick (.+)") { (match: Person) in
+            XCTAssertEqual(match.name, "Nick")
+        }
     }
+}
+
+struct Person: CodableMatchedStringRepresentable {
+    let name: String
 }

--- a/Pod/Core/MatchedStringRepresentable.swift
+++ b/Pod/Core/MatchedStringRepresentable.swift
@@ -38,3 +38,22 @@ extension Int: MatchedStringRepresentable {
         self.init(match, radix: 10)
     }
 }
+
+public protocol CodableMatchedStringRepresentable: Codable, CustomStringConvertible, MatchedStringRepresentable {}
+
+extension CodableMatchedStringRepresentable {
+    public init?(fromMatch match: String) {
+        let decoder = JSONDecoder()
+        guard let data = match.data(using: .utf8),
+            let decoded = try? decoder.decode(Self.self, from: data) else {
+                return nil
+        }
+        self = decoded
+    }
+
+    public var description: String {
+        let encoder = JSONEncoder()
+        let encoded = try! encoder.encode(self)
+        return String(data: encoded, encoding: .utf8)!
+    }
+}

--- a/README.md
+++ b/README.md
@@ -72,6 +72,28 @@ step("This value should be between ([0-9]*) and ([0-9]*)") { (match1: String, ma
 }
 ```
 
+### Captured value types
+
+In step definition with captured values you can use any type conforming to `MatchedStringRepresentable`. `String`, `Double`, `Int` and `Bool` types already conform to this protocol. You can also match your custom types by conforming them to `CodableMatchedStringRepresentable`. This requires type to implement only `Codable` protocol methods, `MatchedStringRepresentable` implementation is provided by the library.
+
+```swift
+struct Person: Codable, Equatable {
+  let name: String
+}
+extension Person: CodableMatchedStringRepresentable {
+}
+
+step("User is logged in as (.+)") { (match: Person) in
+    let loggedInUser = ...
+    XCTAssertEqual(loggedInUser, match)
+}
+
+func testLoggedInUser() {
+    let nick = Person(name: "Nick")
+    Given("User is loggeed in as \(nick)")
+}
+```
+
 ### Examples and feature outlines
 If you want to test the same situation with a set of data, Gherkin allows you to specify example input for your tests. We used this all over our previous tests so we needed to deal with it here too!
 


### PR DESCRIPTION
I found it useful to be able to use complex types in tests descriptions and `Codable` can be easily utilized for that. For that new protocol is introduced.

I.e. I can have a test step that is "I receive push \(notification)" where `notification` is the same DTO that is used by the app.

There is one small caveat for this approach which is an override of `description` property so that `print` will output JSON string.