### PR TITLE
Print suggested steps when can't find step definition

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		951EBB68774F5A1E4BCE21313399489E /* XCTest-Gherkin-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 181150396740E10AC903C43EBBEC2FCB /* XCTest-Gherkin-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		991AF21699C2475520690C878D3BEA00 /* XCGNativeInitializer.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DDFB8A35AEB0A7A16C3E61EB882D8ED /* XCGNativeInitializer.m */; };
 		B0574E2F870C543589955239CC3A79BD /* Pods-XCTest-Gherkin_Example-XCTest-Gherkin_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F6240B366BBDD38ACD9F7015FB6F59F /* Pods-XCTest-Gherkin_Example-XCTest-Gherkin_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B5608ACA2120B7E2001050BD /* LevenshteinDistance.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5608AC92120B7E2001050BD /* LevenshteinDistance.swift */; };
 		C7D930F0B76BE31308D68A737CACA2E2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5D8173434FE00016739EAFDEFEA9313 /* Foundation.framework */; };
 		D4EFDA83D1AAC20D3BA64C4163F5ED0E /* NativeFeatureParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2068A8941D40E26ED01C43985008C844 /* NativeFeatureParser.swift */; };
 		DC1107F0E6C0DAD2336CA3DDE3EC60C7 /* Pods-XCTest-Gherkin_Example-XCTest-Gherkin_ExampleUITests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 622F8FD1EA4AE7DF9F918C398505DCFB /* Pods-XCTest-Gherkin_Example-XCTest-Gherkin_ExampleUITests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -114,6 +115,7 @@
 		A7ED203950C11298DC8DCE3A2B917871 /* NativeRunner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NativeRunner.swift; path = Pod/Native/NativeRunner.swift; sourceTree = "<group>"; };
 		A8EE762885E96812934824CB46F9CB0B /* XCGNativeInitializer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = XCGNativeInitializer.h; path = Pod/Native/XCGNativeInitializer.h; sourceTree = "<group>"; };
 		AC61C9287EE2820EC11CE3CAE86CF750 /* XCTest-Gherkin-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "XCTest-Gherkin-dummy.m"; sourceTree = "<group>"; };
+		B5608AC92120B7E2001050BD /* LevenshteinDistance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LevenshteinDistance.swift; path = Pod/Core/LevenshteinDistance.swift; sourceTree = "<group>"; };
 		C1932CEFC9A084B9139E289204C34AE2 /* XCTest-Gherkin.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "XCTest-Gherkin.modulemap"; sourceTree = "<group>"; };
 		C1C2C2C603007185EB49570BB95906F1 /* MatchedStringRepresentable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatchedStringRepresentable.swift; path = Pod/Core/MatchedStringRepresentable.swift; sourceTree = "<group>"; };
 		C6B18CBA5206666F6C6E823548F72E2B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -228,6 +230,7 @@
 				15A8DA0248CF012D478850A2D74DCCDC /* StepDefiner.swift */,
 				7761BE9A4E52127485488C27805B6304 /* StringGherkinExtension.swift */,
 				159B4BDA420315E192E810A1AF4875AD /* XCTestCase+Gherkin.swift */,
+				B5608AC92120B7E2001050BD /* LevenshteinDistance.swift */,
 			);
 			name = Core;
 			sourceTree = "<group>";
@@ -522,6 +525,7 @@
 				D4EFDA83D1AAC20D3BA64C4163F5ED0E /* NativeFeatureParser.swift in Sources */,
 				5BDE19B03656371487850C9B022D0DBE /* NativeRunner.swift in Sources */,
 				5F711920C33567FE22F7A60431D07F54 /* NativeScenario.swift in Sources */,
+				B5608ACA2120B7E2001050BD /* LevenshteinDistance.swift in Sources */,
 				19A79C16150500C349F9696718122A82 /* NativeTestCase.swift in Sources */,
 				383C9F5FA56A22CD63C43A3F3F79D72F /* ParseState.swift in Sources */,
 				1AFED5D03C150FE4C3B783CDC5F819CA /* Step.swift in Sources */,

--- a/Pod/Core/LevenshteinDistance.swift
+++ b/Pod/Core/LevenshteinDistance.swift
@@ -1,0 +1,60 @@
+// https://en.wikipedia.org/wiki/Levenshtein_distance#Iterative_with_two_matrix_rows
+extension String {
+
+    subscript(_ i: Int) -> Character {
+        return self[self.index(self.startIndex, offsetBy: i)]
+    }
+
+    func levenshteinDistance(_ target: String) -> Int {
+        // create two work vectors of integer distances
+        var last, current: [Int]
+
+        // initialize v0 (the previous row of distances)
+        // this row is A[0][i]: edit distance for an empty s
+        // the distance is just the number of characters to delete from t
+        last = [Int](0...target.count)
+        current = [Int](repeating: 0, count: target.count + 1)
+
+        for i in 0..<self.count {
+            // calculate v1 (current row distances) from the previous row v0
+
+            // first element of v1 is A[i+1][0]
+            //   edit distance is delete (i+1) chars from s to match empty t
+            current[0] = i + 1
+
+            // use formula to fill in the rest of the row
+            for j in 0..<target.count {
+                current[j+1] = Swift.min(
+                    last[j+1] + 1,
+                    current[j] + 1,
+                    last[j] + (self[i] == target[j] ? 0 : 1)
+                )
+            }
+
+            // copy v1 (current row) to v0 (previous row) for next iteration
+            last = current
+        }
+
+        return current[target.count]
+    }
+
+}
+
+extension GherkinState {
+    func suggestedSteps(forStep expression: String) -> [String] {
+        let allSteps = steps.map({ $0.expression })
+
+        let stepsWithDistance = allSteps
+            .map({ (expression: $0, distance: $0.levenshteinDistance(expression)) })
+            // do not suggest steps which expressions are shorter than the distance
+            .filter({ $0.expression.count > $0.distance })
+
+        guard let minDistance = stepsWithDistance.min(by: { $0.distance < $1.distance })?.distance else {
+            return []
+        }
+
+        // suggest all steps with the same distance
+        let suggestedSteps = stepsWithDistance.filter({ $0.distance == minDistance }).map({ $0.expression })
+        return suggestedSteps
+    }
+}

--- a/Pod/Core/LevenshteinDistance.swift
+++ b/Pod/Core/LevenshteinDistance.swift
@@ -41,20 +41,20 @@ extension String {
 }
 
 extension GherkinState {
-    func suggestedSteps(forStep expression: String) -> [String] {
-        let allSteps = steps.map({ $0.expression })
-
-        let stepsWithDistance = allSteps
-            .map({ (expression: $0, distance: $0.levenshteinDistance(expression)) })
+    func suggestedSteps(forStep expression: String) -> [Step] {
+        let stepsWithDistance = steps.sorted(by: { $0.expression < $1.expression })
+            .map({
+                (step: $0, distance: $0.expression.levenshteinDistance(expression))
+            })
             // do not suggest steps which expressions are shorter than the distance
-            .filter({ $0.expression.count > $0.distance })
+            .filter({ $0.step.expression.count > $0.distance })
 
         guard let minDistance = stepsWithDistance.min(by: { $0.distance < $1.distance })?.distance else {
             return []
         }
 
         // suggest all steps with the same distance
-        let suggestedSteps = stepsWithDistance.filter({ $0.distance == minDistance }).map({ $0.expression })
-        return suggestedSteps
+        let suggestedSteps = stepsWithDistance.filter({ $0.distance == minDistance })
+        return suggestedSteps.map({ $0.step })
     }
 }

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -109,7 +109,7 @@ class GherkinState: NSObject, XCTestObservation {
             let suggestedSteps = self.suggestedSteps(forStep: $0)
             if !suggestedSteps.isEmpty {
                 print("-------------\nOr maybe you meant one of these steps:\n-------------")
-                suggestedSteps.forEach({ print($0) })
+                print(suggestedSteps.map { String(reflecting: $0) }.joined(separator: "\n"))
             }
         })
         print("-------------")

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -80,16 +80,12 @@ class GherkinState: NSObject, XCTestObservation {
     func matchingGherkinStepExpressionFound(_ expression: String) -> Bool {
         let matches = self.gherkinStepsMatchingExpression(expression)
         switch matches.count {
-            
         case 0:
             print("Step definition not found for '\(expression)'")
-            let stepImplementation = "step(\"\(expression)"+"\") {XCTAssertTrue(true)}"
-            self.missingStepsImplementations.append(stepImplementation)
-            
+            self.missingStepsImplementations.append(expression)
         case 1:
             //no issues, so proceed
             return true
-            
         default:
             matches.forEach { NSLog("Matching step : \(String(reflecting: $0))") }
             print("Multiple step definitions found for : '\(expression)'")
@@ -109,7 +105,12 @@ class GherkinState: NSObject, XCTestObservation {
         print("Copy paste these steps in a StepDefiner subclass:")
         print("-------------")
         self.missingStepsImplementations.forEach({
-            print($0)
+            print("step(\"\($0)"+"\") {XCTAssertTrue(true)}")
+            let suggestedSteps = self.suggestedSteps(forStep: $0)
+            if !suggestedSteps.isEmpty {
+                print("-------------\nOr maybe you meant one of these steps:\n-------------")
+                suggestedSteps.forEach({ print($0) })
+            }
         })
         print("-------------")
     }


### PR DESCRIPTION
It might be useful not just to print all step definitions, which can be a lot in large projects, on the event of missing step, but suggest some of them as the most likely match.
Not sure how accurate these suggestions will be in a real life because steps are defined using regular expressions patterns, which are obviously not used when steps are invoked. But should be pretty accurate for cases like typos.

Example:

```
Step definition not found for 'Some value should be between one and 7'
-------------
Defined steps
-------------
...
-------------
Copy paste these steps in a StepDefiner subclass:
-------------
step("Some value should be between one and 7") {XCTAssertTrue(true)}
-------------
Or maybe you meant one of these steps:
-------------
/Some value should be between ([0-9]) and ([0-9])/  (SanitySteps.swift:79)
```