### PR TITLE
Allow using custom example types and access current example values

### DIFF
--- a/Example/Tests/Features/ExampleFeatures.swift
+++ b/Example/Tests/Features/ExampleFeatures.swift
@@ -50,14 +50,29 @@ final class ExampleFeatures: XCTestCase {
         Outline {
             Given("I use the example name <name>")
             Then("The age should be <age>")
+            Then("The height should be <height>")
         }
     }
 
+    let examplesDictionary: [[String: ExampleStringRepresentable]] = [
+        [
+            "name": "Alice",
+            "age": 20,
+            "height": 170
+        ],
+        [
+            "name": "Bob",
+            "age": 20,
+            "height": 170
+        ]
+    ]
+
     func testReusableExamples2() {
-        Examples(examples)
+        Examples(examplesDictionary)
 
         Outline {
             Given("I use the example name <name>")
+            Then("The age should be <age>")
             Then("The height should be <height>")
         }
     }
@@ -127,20 +142,4 @@ final class ExampleFeatures: XCTestCase {
         }
     }
 
-    func testDataTable() {
-        Examples(
-            ["persons"],
-            [
-                [Person(name: "Alice", age: 27, height: 170),
-                Person(name: "Bob", age: 27, height: 170)]
-            ]
-        )
-
-        Outline {
-            Given("I know these <persons>")
-            
-            let persons: [Person] = self.exampleValue("persons")!
-            Given("I know these \(persons)")
-        }
-    }
 }

--- a/Example/Tests/Features/ExampleFeatures.swift
+++ b/Example/Tests/Features/ExampleFeatures.swift
@@ -138,6 +138,9 @@ final class ExampleFeatures: XCTestCase {
 
         Outline {
             Given("I know these <persons>")
+            
+            let persons: [Person] = self.exampleValue("persons")!
+            Given("I know these \(persons)")
         }
     }
 }

--- a/Example/Tests/Features/ExampleFeatures.swift
+++ b/Example/Tests/Features/ExampleFeatures.swift
@@ -37,11 +37,11 @@ final class ExampleFeatures: XCTestCase {
             Then("The age should be <age>")
         }
     }
-    
-    let examples = [
+
+    let examples: [[ExampleStringRepresentable]] = [
         [ "name",   "age", "height" ],
-        [  "Alice",  "20",  "170"   ],
-        [  "Bob",    "20",  "170"   ]
+        [  "Alice",  20,  170   ],
+        [  "Bob",    20,  170   ]
     ]
     
     func testReusableExamples1() {
@@ -55,10 +55,42 @@ final class ExampleFeatures: XCTestCase {
 
     func testReusableExamples2() {
         Examples(examples)
-        
+
         Outline {
             Given("I use the example name <name>")
             Then("The height should be <height>")
+        }
+    }
+
+    func testAccessCurrentExampleValue() {
+        Examples(examples)
+
+        Outline {
+            let name: String = self.exampleValue("name")!
+            let height: String = self.exampleValue("height")!
+
+            Given("I use the example name \(name)")
+            Then("The height should be \(height)")
+        }
+    }
+
+    struct Person: CodableMatchedStringRepresentable {
+        let name: String
+        let age: Int
+        let height: Int
+    }
+
+    func testCustomExampleValues() {
+        Examples(
+            ["person"],
+            [Person(name: "Bob", age: 27, height: 170)]
+        )
+
+        Outline {
+            let person: Person = self.exampleValue("person")!
+
+            Given("I use the example name \(person.name)")
+            Then("The height should be \(person.height)")
         }
     }
 
@@ -83,7 +115,15 @@ final class ExampleFeatures: XCTestCase {
     }
 
     func testCodableMatches() {
-        let person = Person(name: "Nick")
-        Given("This is Nick \(person)")
+        Examples(
+            ["person"],
+            [Person(name: "Alice", age: 27, height: 170)],
+            [Person(name: "Bob", age: 27, height: 170)]
+        )
+
+        Outline {
+            let person: Person = self.exampleValue("person")!
+            Given("I know \(person)")
+        }
     }
 }

--- a/Example/Tests/Features/ExampleFeatures.swift
+++ b/Example/Tests/Features/ExampleFeatures.swift
@@ -126,4 +126,18 @@ final class ExampleFeatures: XCTestCase {
             Given("I know \(person)")
         }
     }
+
+    func testDataTable() {
+        Examples(
+            ["persons"],
+            [
+                [Person(name: "Alice", age: 27, height: 170),
+                Person(name: "Bob", age: 27, height: 170)]
+            ]
+        )
+
+        Outline {
+            Given("I know these <persons>")
+        }
+    }
 }

--- a/Example/Tests/StepDefinitions/SanitySteps.swift
+++ b/Example/Tests/StepDefinitions/SanitySteps.swift
@@ -123,12 +123,8 @@ final class SanitySteps: StepDefiner {
             // This step should match instead of the one above, even though the other one is defined first
         }
 
-        step("This is Nick (.+)") { (match: Person) in
-            XCTAssertEqual(match.name, "Nick")
+        step("I know (.+)") { (match: ExampleFeatures.Person) in
+            XCTAssertTrue(match.name == "Alice" || match.name == "Bob")
         }
     }
-}
-
-struct Person: CodableMatchedStringRepresentable {
-    let name: String
 }

--- a/Example/Tests/StepDefinitions/SanitySteps.swift
+++ b/Example/Tests/StepDefinitions/SanitySteps.swift
@@ -126,5 +126,10 @@ final class SanitySteps: StepDefiner {
         step("I know (.+)") { (match: ExampleFeatures.Person) in
             XCTAssertTrue(match.name == "Alice" || match.name == "Bob")
         }
+        
+        step("I know these (.+)") { (match: [ExampleFeatures.Person]) in
+            XCTAssertTrue(match[0].name == "Alice" || match[1].name == "Bob")
+        }
+
     }
 }

--- a/Pod/Core/Example.swift
+++ b/Pod/Core/Example.swift
@@ -12,7 +12,7 @@ import XCTest
 // Yep, turns out that an example is just a dictionary :)
 
 typealias ExampleTitle = String
-typealias ExampleValue = String
+typealias ExampleValue = Any
 
 /**
  An Example represents a single row in the Examples(...) block in a test
@@ -96,6 +96,12 @@ public extension XCTestCase {
     }
 
     func exampleValue<T: ExampleStringRepresentable>(_ title: String) -> T? {
-        return state.currentExample?[title].flatMap(T.init(fromMatch:))
+        let value = state.currentExample?[title]
+        if let value = value as? T {
+            return value
+        } else if let value = value as? String {
+            return T(fromMatch: value)
+        }
+        return nil
     }
 }

--- a/Pod/Core/Example.swift
+++ b/Pod/Core/Example.swift
@@ -37,6 +37,23 @@ public extension XCTestCase {
         Examples(all)
     }
 
+
+    @nonobjc
+    func Examples(_ values: [[String: ExampleStringRepresentable]]) {
+        var titles = [String]()
+        var allValues = [[ExampleStringRepresentable]](repeating: [], count: values.count)
+
+        values.enumerated().forEach { (example) in
+            example.element.sorted(by: { $0.key < $1.key }).forEach({
+                if !titles.contains($0.key) {
+                    titles.append($0.key)
+                }
+                allValues[example.offset] = allValues[example.offset] + [$0.value]
+            })
+        }
+        Examples([titles] + allValues)
+    }
+
     /**
      If you want to reuse examples between tests then you can just pass in an array of examples directly.
 

--- a/Pod/Core/Example.swift
+++ b/Pod/Core/Example.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import XCTest
 
 // Yep, turns out that an example is just a dictionary :)
 

--- a/Pod/Core/Example.swift
+++ b/Pod/Core/Example.swift
@@ -17,3 +17,84 @@ typealias ExampleValue = String
  An Example represents a single row in the Examples(...) block in a test
  */
 typealias Example = [ExampleTitle: ExampleValue]
+
+public typealias ExampleStringRepresentable = MatchedStringRepresentable
+
+public extension XCTestCase {
+    /**
+     Supply a set of example data to the test. This must be done before calling `Outline`.
+
+     If you specify a set of examples but don't run the test inside an `Outline { }` block then it won't do anything!
+
+     - parameter titles: The titles for each column; these are the keys used to replace the placeholders in each step
+     - parameter allValues: This is an array of columns - each array will be used as a single test
+     */
+    func Examples(_ titles: [String], _ allValues: [ExampleStringRepresentable]...) {
+        var all = [titles]
+        let values = allValues.map { $0.map { String(describing: $0) } }
+        all.append(contentsOf: values)
+        Examples(all)
+    }
+
+    /**
+     If you want to reuse examples between tests then you can just pass in an array of examples directly.
+
+     let examples = [
+         [ "title", "age" ],
+         [ "a",     "20"  ],
+         [ "b",     "25"  ]
+     ]
+
+     ...
+
+     Examples(examples)
+
+     */
+    func Examples(_ values: [[ExampleStringRepresentable]]) {
+        precondition(values.count > 1, "You must pass at least one set of example data")
+
+        // Split out the titles and the example data
+        let titles = values.first!
+        let allValues = values.dropFirst()
+
+        // TODO: Hints at a reduce, but we're going over two arrays at once . . . :|
+        var accumulator = Array<Example>()
+        allValues.forEach { values in
+            precondition(values.count == titles.count, "Each example must be the same size as the titles (was \(values.count), expected \(titles.count))")
+
+            // Loop over both titles and values, creating a dictionary (i.e. an Example)
+            var example = Example()
+            (0..<titles.count).forEach { n in
+                let title = String(describing: titles[n])
+                let value = String(describing: values[n])
+                example[title] = value
+            }
+
+            accumulator.append(example)
+        }
+
+        state.examples = accumulator
+    }
+
+    /**
+     Run the following steps as part of an outline - this will replace any placeholders with each example in turn.
+
+     You must have setup the example cases before calling this; use `Example(...)` to do this.
+
+     - parameter routine: A block containing your Given/When/Then which will be run once per example
+     */
+    func Outline( _ routine: ()->() ) {
+        precondition(state.examples != nil, "You need to define examples before running an Outline block - use Examples(...)");
+        precondition(state.examples!.count > 0, "You've called Examples but haven't passed anything in. Nice try.")
+
+        state.examples!.forEach { example in
+            state.currentExample = example
+            routine()
+            state.currentExample = nil
+        }
+    }
+
+    func exampleValue<T: ExampleStringRepresentable>(_ title: String) -> T? {
+        return state.currentExample?[title].flatMap(T.init(fromMatch:))
+    }
+}

--- a/Pod/Core/Example.swift
+++ b/Pod/Core/Example.swift
@@ -12,7 +12,7 @@ import XCTest
 // Yep, turns out that an example is just a dictionary :)
 
 typealias ExampleTitle = String
-typealias ExampleValue = Any
+typealias ExampleValue = ExampleStringRepresentable
 
 /**
  An Example represents a single row in the Examples(...) block in a test

--- a/Pod/Core/MatchedStringRepresentable.swift
+++ b/Pod/Core/MatchedStringRepresentable.swift
@@ -57,3 +57,5 @@ extension CodableMatchedStringRepresentable {
         return String(data: encoded, encoding: .utf8)!
     }
 }
+
+extension Array: CodableMatchedStringRepresentable where Element: CodableMatchedStringRepresentable {}

--- a/Pod/Core/MatchedStringRepresentable.swift
+++ b/Pod/Core/MatchedStringRepresentable.swift
@@ -14,26 +14,22 @@ public protocol MatchedStringRepresentable {
 }
 
 extension MatchedStringRepresentable where Self: LosslessStringConvertible {
-
     public init?(fromMatch match: String) {
         self.init(match)
     }
 }
-
 
 extension String: MatchedStringRepresentable { }
 
 extension Double: MatchedStringRepresentable { }
 
 extension Bool: MatchedStringRepresentable {
-
     public init?(fromMatch match: String) {
         self.init(match.lowercased())
     }
 }
 
 extension Int: MatchedStringRepresentable {
-
     public init?(fromMatch match: String) {
         self.init(match, radix: 10)
     }
@@ -57,5 +53,21 @@ extension CodableMatchedStringRepresentable {
         return String(data: encoded, encoding: .utf8)!
     }
 }
+// For some reason extending array with CodableMatchedStringRepresentable makes `pod lint` to fail
+// but this way it works and its sufficient as CodableMatchedStringRepresentable is just a composition of protocols 🤷‍♂️
+extension Array: MatchedStringRepresentable where Element: CodableMatchedStringRepresentable {
+    public init?(fromMatch match: String) {
+        let decoder = JSONDecoder()
+        guard let data = match.data(using: .utf8),
+            let decoded = try? decoder.decode([Element].self, from: data) else {
+                return nil
+        }
+        self = decoded
+    }
 
-extension Array: CodableMatchedStringRepresentable where Element: CodableMatchedStringRepresentable {}
+    public var description: String {
+        let encoder = JSONEncoder()
+        let encoded = try! encoder.encode(self)
+        return String(data: encoded, encoding: .utf8)!
+    }
+}

--- a/Pod/Core/StepDefiner.swift
+++ b/Pod/Core/StepDefiner.swift
@@ -113,7 +113,7 @@ open class StepDefiner: NSObject, XCTestObservation {
     }
 
     /**
-     Create a new step with an expression that contains one matching groups to match collection of `MatchedStringRepresentable` values
+     Create a new step with an expression that contains one matching group to match collection of `MatchedStringRepresentable` values
 
      - parameter expression: The expression to match against
      - parameter f: The step definition to be run, passing in the first capture group from the expression
@@ -125,12 +125,12 @@ open class StepDefiner: NSObject, XCTestObservation {
                 return
             }
 
-            guard let integer = T(fromMatch: match) else {
+            guard let value = T(fromMatch: match) else {
                 XCTFail("Could not convert \"\(match)\" to \(T.self)")
                 return
             }
 
-            f(integer)
+            f(value)
         }
     }
 

--- a/Pod/Core/StepDefiner.swift
+++ b/Pod/Core/StepDefiner.swift
@@ -111,7 +111,29 @@ open class StepDefiner: NSObject, XCTestObservation {
             f1(integer)
         }
     }
-    
+
+    /**
+     Create a new step with an expression that contains one matching groups to match collection of `MatchedStringRepresentable` values
+
+     - parameter expression: The expression to match against
+     - parameter f: The step definition to be run, passing in the first capture group from the expression
+    */
+    open func step<T: Collection & MatchedStringRepresentable>(_ expression: String, file: String = #file, line: Int = #line, f: @escaping (T)->()) {
+        self.test.addStep(expression, file: file, line: line) { (matches: [String]) in
+            guard let match = matches.first else {
+                XCTFail("Expected single match not found in \"\(expression)\"")
+                return
+            }
+
+            guard let integer = T(fromMatch: match) else {
+                XCTFail("Could not convert \"\(match)\" to \(T.self)")
+                return
+            }
+
+            f(integer)
+        }
+    }
+
     /**
      If you only want to match the first two parameters, this will help make your code nicer
      

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -255,7 +255,7 @@ extension XCTestCase {
                 // For each field in the example, go through the step expression and replace the placeholders if needed
                 example.forEach { (key, value) in
                     let needle = "<\(key)>"
-                    expression = (expression as NSString).replacingOccurrences(of: needle, with: value.description)
+                    expression = (expression as NSString).replacingOccurrences(of: needle, with: String(describing: value))
                 }
             }
             

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -181,77 +181,6 @@ public extension XCTestCase {
      */
     func And(_ expression: String, file: StaticString = #file, line: UInt = #line) { self.performStep(expression, file: file, line: line) }
     
-    /**
-     Supply a set of example data to the test. This must be done before calling `Outline`.
-     
-     If you specify a set of examples but don't run the test inside an `Outline { }` block then it won't do anything!
-     
-     - parameter titles: The titles for each column; these are the keys used to replace the placeholders in each step
-     - parameter allValues: This is an array of columns - each array will be used as a single test
-     */
-    func Examples(_ titles: [String], _ allValues: [String]...) {
-        var all = [titles]
-        all.append(contentsOf: allValues)
-        Examples(all)
-    }
-    
-    /**
-     If you want to reuse examples between tests then you can just pass in an array of examples directly.
-     
-         let examples = [ 
-                [ "title", "age" ],
-                [ "a",     "20"  ],
-                [ "b",     "25"  ]
-            ]
-     
-         ...
-     
-         Examples(examples)
-     
-     */
-    func Examples(_ values: [[String]]) {
-        precondition(values.count > 1, "You must pass at least one set of example data")
-        
-        // Split out the titles and the example data
-        let titles = values.first!
-        let allValues = values.dropFirst()
-        
-        // TODO: Hints at a reduce, but we're going over two arrays at once . . . :|
-        var accumulator = Array<Example>()
-        allValues.forEach { values in
-            precondition(values.count == titles.count, "Each example must be the same size as the titles (was \(values.count), expected \(titles.count))")
-            
-            // Loop over both titles and values, creating a dictionary (i.e. an Example)
-            var example = Example()
-            (0..<titles.count).forEach { n in
-                example[titles[n]] = values[n]
-            }
-            
-            accumulator.append(example)
-        }
-        
-        state.examples = accumulator
-    }
-    
-    /**
-     Run the following steps as part of an outline - this will replace any placeholders with each example in turn.
-
-     You must have setup the example cases before calling this; use `Example(...)` to do this.
-     
-     - parameter routine: A block containing your Given/When/Then which will be run once per example
-     */
-    func Outline( _ routine: ()->() ) {
-        
-        precondition(state.examples != nil, "You need to define examples before running an Outline block - use Examples(...)");
-        precondition(state.examples!.count > 0, "You've called Examples but haven't passed anything in. Nice try.")
-        
-        state.examples!.forEach { example in
-            state.currentExample = example
-            routine()
-            state.currentExample = nil
-        }
-    }
-    
 }
 
 private var automaticScreenshotsBehaviour: AutomaticScreenshotsBehaviour = .none
@@ -326,7 +255,7 @@ extension XCTestCase {
                 // For each field in the example, go through the step expression and replace the placeholders if needed
                 example.forEach { (key, value) in
                     let needle = "<\(key)>"
-                    expression = (expression as NSString).replacingOccurrences(of: needle, with: value)
+                    expression = (expression as NSString).replacingOccurrences(of: needle, with: value.description)
                 }
             }
             


### PR DESCRIPTION
This PR adds support for custom types as an example value. It takes advantage of earlier introduced `CodableMatchedStringRepresentable`, so types conforming to this protocol can be used both as example values and step match values. Also, any `MatchedStringRepresentable` type can be used as an example value.

This also adds a method to access current example values. It is useful in case some additional operations on data are needed in outline, i.e.:

```swift
func testNotificationOfSomeType() {
        Examples(
            ["notification_type"],
            [NotificationType.missedCall],
            ...
        )

        Outline(shouldTerminate: true) {
            let notificationType = self.notificationTypeFromExample()
            let notification = PushNotificationDTO.appointmentNotification(notificationType, appointmentId: "1")

            When("I receive notification \(notification)")
            ...
        }
}
```

This also allows to add support for data tables (so resolves #41) aka arrays of custom types as example values, i.e.:

```swift
func testDataTable() {
        Examples(
            ["persons"],
            [[
                Person(name: "Alice", age: 27, height: 170),
                Person(name: "Bob", age: 27, height: 170)
            ]]
        )

        Outline {
            Given("I know these <persons>")
        }
}

        step("I know these (.+)") { (match: [ExampleFeatures.Person]) in
            XCTAssertTrue(match[0].name == "Alice" || match[1].name == "Bob")
        }
```

Also moved methods related to examples functionality into `Examples.swift` as `XCTestCase+Gherkin.swift` grows bigger than swiftlint lines number limit.