### PR TITLE
Fix automatic screenshots behaviour

### DIFF
--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -57,11 +57,10 @@ class GherkinState: NSObject, XCTestObservation {
         let file = "\(currentStepLocation.file)"
         let line = Int(currentStepLocation.line)
         guard filePath != file, lineNumber != line else { return }
-        test.recordFailure(withDescription: description, inFile: file, atLine: line, expected: false)
-
         if automaticScreenshotsBehaviour.contains(.onFailure) {
             test.attachScreenshot()
         }
+        test.recordFailure(withDescription: description, inFile: file, atLine: line, expected: false)
     }
 
     func gherkinStepsAndMatchesMatchingExpression(_ expression: String) -> [(step: Step, match: NSTextCheckingResult)] {

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -60,7 +60,7 @@ class GherkinState: NSObject, XCTestObservation {
         test.recordFailure(withDescription: description, inFile: file, atLine: line, expected: false)
 
         if automaticScreenshotsBehaviour.contains(.onFailure) {
-            test.attachScreenshot(name: "Failed \"\(currentStepName)\"")
+            test.attachScreenshot()
         }
     }
 
@@ -282,13 +282,12 @@ extension XCTestCase {
         automaticScreenshotsLifetime = lifetime
     }
 
-    func attachScreenshot(name: String) {
+    func attachScreenshot() {
         // if tests have no host app there is no point in making screenshots
         guard Bundle.main.bundlePath.hasSuffix(".app") else { return }
 
         let screenshot = XCUIScreen.main.screenshot()
         let attachment = XCTAttachment(screenshot: screenshot, quality: automaticScreenshotsQuality)
-        attachment.name = name
         attachment.lifetime = automaticScreenshotsLifetime
         add(attachment)
     }
@@ -367,11 +366,11 @@ extension XCTestCase {
             state.currentStepDepth += 1
             state.currentStepLocation = (file, line)
             if automaticScreenshotsBehaviour.contains(.beforeStep) {
-                attachScreenshot(name: "Before \"\(expression)\"")
+                attachScreenshot()
             }
             step.function(matchStrings)
             if automaticScreenshotsBehaviour.contains(.afterStep) {
-                attachScreenshot(name: "After \"\(expression)\"")
+                attachScreenshot()
             }
             state.currentStepLocation = nil
             state.currentStepDepth -= 1


### PR DESCRIPTION
This PR contains two fixes for automatic screenshots behaviour:

- when `continueAfterFailure` is set to `true` screenshots are not taken on failures
- step expressions can be strings which are not appropriate for file names, so they now don't set custom name