### PR TITLE
Highlight line in feature file when step fails

### DIFF
--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -54,7 +54,7 @@ class GherkinState: NSObject, XCTestObservation {
 
     func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
         guard let test = self.test, let (file, line) = test.state.currentStepLocation else { return }
-        guard filePath != file, lineNumber != line else { return }
+        if filePath == file && lineNumber == line { return }
         if automaticScreenshotsBehaviour.contains(.onFailure) {
             test.attachScreenshot()
         }

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -53,10 +53,9 @@ class GherkinState: NSObject, XCTestObservation {
     }
 
     func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
-        guard let test = self.test, let currentStepLocation = test.state.currentStepLocation else { return }
-        let file = "\(currentStepLocation.file)"
-        let line = Int(currentStepLocation.line)
+        guard let test = self.test, let (file, line) = test.state.currentStepLocation else { return }
         guard filePath != file, lineNumber != line else { return }
+
         test.recordFailure(withDescription: description, inFile: file, atLine: line, expected: false)
 
         if automaticScreenshotsBehaviour.contains(.onFailure) {

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -27,7 +27,7 @@ class GherkinState: NSObject, XCTestObservation {
     var currentStepDepth: Int = 0
     
     // file and line from where currently executed step was invoked
-    var currentStepLocation: (file: StaticString, line: UInt)!
+    var currentStepLocation: (file: String, line: Int)!
 
     // When we are in an Outline block, this defines the examples to loop over
     var examples: [Example]?
@@ -164,22 +164,22 @@ public extension XCTestCase {
     /**
      Run the step matching the specified expression
      */
-    func Given(_ expression: String, file: StaticString = #file, line: UInt = #line) { self.performStep(expression, file: file, line: line) }
+    func Given(_ expression: String, file: String = #file, line: Int = #line) { self.performStep(expression, file: file, line: line) }
     
     /**
      Run the step matching the specified expression
      */
-    func When(_ expression: String, file: StaticString = #file, line: UInt = #line) { self.performStep(expression, file: file, line: line) }
+    func When(_ expression: String, file: String = #file, line: Int = #line) { self.performStep(expression, file: file, line: line) }
     
     /**
      Run the step matching the specified expression
      */
-    func Then(_ expression: String, file: StaticString = #file, line: UInt = #line) { self.performStep(expression, file: file, line: line) }
+    func Then(_ expression: String, file: String = #file, line: Int = #line) { self.performStep(expression, file: file, line: line) }
     
     /**
      Run the step matching the specified expression
      */
-    func And(_ expression: String, file: StaticString = #file, line: UInt = #line) { self.performStep(expression, file: file, line: line) }
+    func And(_ expression: String, file: String = #file, line: Int = #line) { self.performStep(expression, file: file, line: line) }
     
     /**
      Supply a set of example data to the test. This must be done before calling `Outline`.
@@ -311,7 +311,7 @@ extension XCTestCase {
     /**
      Finds and performs a step test based on expression
      */
-    func performStep(_ initialExpression: String, file: StaticString = #file, line: UInt = #line) {
+    func performStep(_ initialExpression: String, file: String = #file, line: Int = #line) {
 
         func perform(expression: String) {
             

--- a/Pod/Native/NativeFeature.swift
+++ b/Pod/Native/NativeFeature.swift
@@ -47,29 +47,27 @@ extension NativeFeature {
     
     convenience init?(contentsOfURL url: URL) {
         // Read in the file
+        let path = url.absoluteString.replacingOccurrences(of: "file://", with: "")
         let contents = try! NSString(contentsOf: url, encoding: String.Encoding.utf8.rawValue)
         
         // Replace new line character that is sometimes used if the Gherkin files have been written on a Windows machine.
         let contentsFixedWindowsNewLineCharacters = contents.replacingOccurrences(of: "\r\n", with: "\n")
         
         // Get all the lines in the file
-        var lines = contentsFixedWindowsNewLineCharacters.components(separatedBy: "\n").map { $0.trimmingCharacters(in: whitespace) }
-
-        // Filter comments (#) and tags (@), also filter white lines
-        lines = lines.filter { $0.first != "#" &&  $0.first != "@" && $0.count > 0}
+        let lines = contentsFixedWindowsNewLineCharacters.components(separatedBy: "\n").map { $0.trimmingCharacters(in: whitespace) }
 
         guard lines.count > 0 else { return nil }
         
         // The feature description needs to be on the first line - we'll fail this method if it isn't!
-        let (_, suffixOption) = lines.first!.componentsWithPrefix(FileTags.Feature)
+        let (_, suffixOption) = lines.filter({ $0.first != "#" &&  $0.first != "@" && $0.count > 0 }).first!.componentsWithPrefix(FileTags.Feature)
         guard let featureDescription = suffixOption else { return nil }
         
-        let feature = NativeFeature.parseLines(lines)
+        let feature = NativeFeature.parseLines(lines, path: path)
         
         self.init(description: featureDescription, scenarios: feature.scenarios, background: feature.background)
     }
     
-    fileprivate class func parseLines(_ lines: [String]) -> (background: NativeBackground?, scenarios: [NativeScenario]) {
+    fileprivate class func parseLines(_ lines: [String], path: String) -> (background: NativeBackground?, scenarios: [NativeScenario]) {
         
         var state = ParseState()
         var scenarios = Array<NativeScenario>()
@@ -85,44 +83,45 @@ extension NativeFeature {
         }
         
         // Go through each line in turn
+        var lineNumber = 0
         for (lineIndex, line) in lines.enumerated() {
-            
-            if !line.isEmpty {
-                // What kind of line is it?
-                if let (linePrefix, lineSuffix) = line.lineComponents() {
-                    
-                    switch(linePrefix) {
-                        
-                    case FileTags.Background :
-                        state = ParseState(description: lineSuffix, parsingBackground: true)
-                        
-                    case FileTags.Scenario :
-                        saveBackgroundOrScenarioAndUpdateParseState(lineSuffix)
-                        
-                    case FileTags.Given, FileTags.When, FileTags.Then, FileTags.And:
-                        state.steps.append(lineSuffix)
-                        
-                    case FileTags.Outline:
-                        saveBackgroundOrScenarioAndUpdateParseState(lineSuffix)
-                        
-                    case FileTags.Examples:
-                        // Prep the examples array for examples
-                        state.exampleLines = []
+            lineNumber += 1
 
-                    case FileTags.ExampleLine:
-                        state.exampleLines.append( (lineIndex+1, lineSuffix) )
-                        
-                    case FileTags.Feature:
-                        break
-                        
-                    default:
-                        // Just ignore lines we don't recognise yet
-                        break
-                    }
-                    
+            // Filter comments (#) and tags (@), also filter white lines
+            guard line.first != "#" &&  line.first != "@" && line.count > 0 else { continue }
+
+            // What kind of line is it?
+            if let (linePrefix, lineSuffix) = line.lineComponents() {
+
+                switch(linePrefix) {
+
+                case FileTags.Background :
+                    state = ParseState(description: lineSuffix, parsingBackground: true)
+
+                case FileTags.Scenario :
+                    saveBackgroundOrScenarioAndUpdateParseState(lineSuffix)
+
+                case FileTags.Given, FileTags.When, FileTags.Then, FileTags.And:
+                    state.steps.append((expression: lineSuffix, file: path, line: lineNumber))
+
+                case FileTags.Outline:
+                    saveBackgroundOrScenarioAndUpdateParseState(lineSuffix)
+
+                case FileTags.Examples:
+                    // Prep the examples array for examples
+                    state.exampleLines = []
+
+                case FileTags.ExampleLine:
+                    state.exampleLines.append( (lineIndex+1, lineSuffix) )
+
+                case FileTags.Feature:
+                    break
+
+                default:
+                    // Just ignore lines we don't recognise yet
+                    break
                 }
             }
-
         }
         
         // If we hit the end of the file, we need to make sure we have dealt with

--- a/Pod/Native/NativeFeature.swift
+++ b/Pod/Native/NativeFeature.swift
@@ -88,7 +88,7 @@ extension NativeFeature {
             // What kind of line is it?
             if let (linePrefix, lineSuffix) = line.lineComponents() {
 
-                switch(linePrefix) {
+                switch (linePrefix) {
 
                 case FileTags.Background :
                     state = ParseState(description: lineSuffix, parsingBackground: true)
@@ -96,11 +96,11 @@ extension NativeFeature {
                 case FileTags.Scenario :
                     saveBackgroundOrScenarioAndUpdateParseState(lineSuffix)
 
-                case FileTags.Given, FileTags.When, FileTags.Then, FileTags.And:
-                    state.steps.append((expression: lineSuffix, file: path, line: lineNumber))
-
                 case FileTags.Outline:
                     saveBackgroundOrScenarioAndUpdateParseState(lineSuffix)
+
+                case FileTags.Given, FileTags.When, FileTags.Then, FileTags.And:
+                    state.steps.append(.init(expression: lineSuffix, file: path, line: lineNumber))
 
                 case FileTags.Examples:
                     // Prep the examples array for examples

--- a/Pod/Native/NativeFeature.swift
+++ b/Pod/Native/NativeFeature.swift
@@ -46,15 +46,10 @@ class NativeFeature: CustomStringConvertible {
 extension NativeFeature {
     
     convenience init?(contentsOfURL url: URL) {
-        // Read in the file
-        let path = url.absoluteString.replacingOccurrences(of: "file://", with: "")
-        let contents = try! NSString(contentsOf: url, encoding: String.Encoding.utf8.rawValue)
-        
-        // Replace new line character that is sometimes used if the Gherkin files have been written on a Windows machine.
-        let contentsFixedWindowsNewLineCharacters = contents.replacingOccurrences(of: "\r\n", with: "\n")
-        
+        guard let data = try? Data(contentsOf: url), let contents = String(data: data, encoding: .utf8) else { return nil }
+
         // Get all the lines in the file
-        let lines = contentsFixedWindowsNewLineCharacters.components(separatedBy: "\n").map { $0.trimmingCharacters(in: whitespace) }
+        let lines = contents.components(separatedBy: CharacterSet.newlines).map { $0.trimmingCharacters(in: whitespace) }
 
         guard lines.count > 0 else { return nil }
         
@@ -62,7 +57,7 @@ extension NativeFeature {
         let (_, suffixOption) = lines.filter({ $0.first != "#" &&  $0.first != "@" && $0.count > 0 }).first!.componentsWithPrefix(FileTags.Feature)
         guard let featureDescription = suffixOption else { return nil }
         
-        let feature = NativeFeature.parseLines(lines, path: path)
+        let feature = NativeFeature.parseLines(lines, path: url.path)
         
         self.init(description: featureDescription, scenarios: feature.scenarios, background: feature.background)
     }

--- a/Pod/Native/NativeRunner.swift
+++ b/Pod/Native/NativeRunner.swift
@@ -15,7 +15,7 @@ open class NativeRunner {
     public class func runScenario(featureFile: String, scenario: String?, testCase: XCTestCase) {
         testCase.state.loadAllStepsIfNeeded()
 
-        guard let path = (Bundle(for: type(of: testCase)).resourceURL?.appendingPathComponent(featureFile)) else {
+        guard let path = Bundle(for: type(of: testCase)).resourceURL?.appendingPathComponent(featureFile) else {
             XCTFail("Path could not be built for feature file: \(featureFile)")
             return
         }

--- a/Pod/Native/NativeScenario.swift
+++ b/Pod/Native/NativeScenario.swift
@@ -8,6 +8,12 @@
 
 import Foundation
 
+struct StepDescription {
+    let expression: String
+    let file: String
+    let line: Int
+}
+
 class NativeScenario: CustomStringConvertible {
     let scenarioDescription: String
     let stepDescriptions: [StepDescription]
@@ -39,6 +45,19 @@ class NativeScenario: CustomStringConvertible {
     
     private func leftPad(_ index: Int) -> NSString {
         return NSString(format: "%03i", index)
+    }
+}
+
+class NativeScenarioOutline: NativeScenario {
+    let examples: [NativeExample]
+
+    required init(_ description: String, steps: [StepDescription], examples: [NativeExample], index: Int = 0) {
+        self.examples = examples
+        super.init(description, steps: steps, index: index)
+    }
+
+    required init(_ description: String, steps: [StepDescription], index: Int) {
+        fatalError("init(_:steps:index:) has not been implemented")
     }
 }
 

--- a/Pod/Native/NativeScenario.swift
+++ b/Pod/Native/NativeScenario.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class NativeScenario: CustomStringConvertible {
     let scenarioDescription: String
-    let stepDescriptions: [String]
+    let stepDescriptions: [StepDescription]
     let index: Int
 
     /**
@@ -25,7 +25,7 @@ class NativeScenario: CustomStringConvertible {
         get { return strdup(self.selectorString) }
     }
     
-    required init(_ description: String, steps: [String], index: Int = 0) {
+    required init(_ description: String, steps: [StepDescription], index: Int = 0) {
         self.scenarioDescription = description
         self.stepDescriptions = steps
         self.index = index

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -107,26 +107,50 @@ open class NativeTestCase: XCGNativeInitializer {
 }
 
 extension XCTestCase {
+    
     func perform(scenario: NativeScenario, from feature: NativeFeature) {
-        let allScenarioStepsDefined = scenario.stepDescriptions
-            .map { state.matchingGherkinStepExpressionFound($0.expression) }
-            .reduce(true) { $0 && $1 }
-        var allFeatureBackgroundStepsDefined = true
-        
-        if let defined = feature.background?.stepDescriptions
-            .map({ state.matchingGherkinStepExpressionFound($0.expression) })
-            .reduce(true, { $0 && $1 }) {
-            allFeatureBackgroundStepsDefined = defined
+        func perform(scenario: NativeScenario) {
+            let allScenarioStepsDefined = scenario.stepDescriptions
+                .map { state.matchingGherkinStepExpressionFound($0.expression) }
+                .reduce(true) { $0 && $1 }
+            var allFeatureBackgroundStepsDefined = true
+
+            if let defined = feature.background?.stepDescriptions
+                .map({ state.matchingGherkinStepExpressionFound($0.expression) })
+                .reduce(true, { $0 && $1 }) {
+                allFeatureBackgroundStepsDefined = defined
+            }
+
+            guard allScenarioStepsDefined && allFeatureBackgroundStepsDefined else {
+                XCTFail("Some step definitions not found for the scenario: \(scenario.scenarioDescription)")
+                return
+            }
+
+            if let background = feature.background {
+                background.stepDescriptions.forEach({ self.performStep($0.expression, file: $0.file, line: $0.line) })
+            }
+
+            scenario.stepDescriptions.forEach({ self.performStep($0.expression, file: $0.file, line: $0.line) })
         }
-        
-        guard allScenarioStepsDefined && allFeatureBackgroundStepsDefined else {
-            XCTFail("Some step definitions not found for the scenario: \(scenario.scenarioDescription)")
-            return
+
+        if let outline = scenario as? NativeScenarioOutline {
+            // Replace each matching placeholder in each line with the example data
+            for (exampleIndex, example) in outline.examples.enumerated() {
+                // This hoop is because the compiler doesn't seem to
+                // recognize map directly on the state.steps object
+                let steps = outline.stepDescriptions.map { step -> StepDescription in
+                    let expression = example.pairs.reduce(step.expression, {
+                        $0.replacingOccurrences(of: "<\($1.key)>", with: $1.value)
+                    })
+                    return StepDescription(expression: expression, file: step.file, line: step.line)
+                }
+
+                self.state.currentNativeExampleLineNumber = example.lineNumber
+                let scenario = NativeScenario(outline.scenarioDescription, steps: steps, index: outline.index + exampleIndex)
+                perform(scenario: scenario)
+            }
+        } else {
+            perform(scenario: scenario)
         }
-        
-        if let background = feature.background {
-            background.stepDescriptions.forEach({ self.performStep($0.expression, file: $0.file, line: $0.line) })
-        }
-        scenario.stepDescriptions.forEach({ self.performStep($0.expression, file: $0.file, line: $0.line) })
     }
 }

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -108,10 +108,14 @@ open class NativeTestCase: XCGNativeInitializer {
 
 extension XCTestCase {
     func perform(scenario: NativeScenario, from feature: NativeFeature) {
-        let allScenarioStepsDefined = scenario.stepDescriptions.map(state.matchingGherkinStepExpressionFound).reduce(true) { $0 && $1 }
+        let allScenarioStepsDefined = scenario.stepDescriptions
+            .map { state.matchingGherkinStepExpressionFound($0.expression) }
+            .reduce(true) { $0 && $1 }
         var allFeatureBackgroundStepsDefined = true
         
-        if let defined = feature.background?.stepDescriptions.map(state.matchingGherkinStepExpressionFound).reduce(true, { $0 && $1 }) {
+        if let defined = feature.background?.stepDescriptions
+            .map({ state.matchingGherkinStepExpressionFound($0.expression) })
+            .reduce(true, { $0 && $1 }) {
             allFeatureBackgroundStepsDefined = defined
         }
         
@@ -121,8 +125,8 @@ extension XCTestCase {
         }
         
         if let background = feature.background {
-            background.stepDescriptions.forEach({ self.performStep($0) })
+            background.stepDescriptions.forEach({ self.performStep($0.expression, file: $0.file, line: $0.line) })
         }
-        scenario.stepDescriptions.forEach({ self.performStep($0) })
+        scenario.stepDescriptions.forEach({ self.performStep($0.expression, file: $0.file, line: $0.line) })
     }
 }

--- a/Pod/Native/ParseState.swift
+++ b/Pod/Native/ParseState.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 private let whitespace = CharacterSet.whitespaces
-typealias StepDescription = (expression: String, file: String, line: Int)
 
 class ParseState {
     var description: String?
@@ -74,25 +73,7 @@ class ParseState {
         if self.examples.isEmpty {
             scenarios.append(NativeScenario(description, steps: self.steps, index: index))
         } else {
-            // Replace each matching placeholder in each line with the example data
-            for (exampleIndex, example) in self.examples.enumerated() {
-                // This hoop is because the compiler doesn't seem to
-                // recognize map directly on the state.steps object
-                var steps = self.steps
-                steps = self.steps.map { originalStep in
-                    var step = originalStep
-                    
-                    example.pairs.forEach { (title, value) in
-                        step.expression = step.expression.replacingOccurrences(of: "<\(title)>", with: value)
-                    }
-                    
-                    return step
-                }
-                
-                // The scenario description must be unique
-                let description = "\(description)_line\(example.lineNumber)"
-                scenarios.append(NativeScenario(description, steps: steps, index: index + exampleIndex))
-            }
+            scenarios.append(NativeScenarioOutline(description, steps: self.steps, examples: self.examples, index: index))
         }
         
         self.description = nil

--- a/Pod/Native/ParseState.swift
+++ b/Pod/Native/ParseState.swift
@@ -9,10 +9,11 @@
 import Foundation
 
 private let whitespace = CharacterSet.whitespaces
+typealias StepDescription = (expression: String, file: String, line: Int)
 
 class ParseState {
     var description: String?
-    var steps: [String]
+    var steps: [StepDescription]
     var exampleLines: [(lineNumber: Int, line: String)]
     var parsingBackground: Bool
 
@@ -82,7 +83,7 @@ class ParseState {
                     var step = originalStep
                     
                     example.pairs.forEach { (title, value) in
-                        step = step.replacingOccurrences(of: "<\(title)>", with: value)
+                        step.expression = step.expression.replacingOccurrences(of: "<\(title)>", with: value)
                     }
                     
                     return step


### PR DESCRIPTION
The current implementation of feature file parser skips empty lines, tags, and comments, so in result line number of steps may be incorrect. This PR fixes this to allow proper highlighting of failed steps in feature files like it was done for native tests in #106 

Also added highlighting of failed examples in scenario outlines.

Result:

<img width="398" alt="screen shot 2018-09-01 at 14 40 09" src="https://user-images.githubusercontent.com/1488293/44946484-0eb2ed00-adf5-11e8-9d39-215c5ca890e7.png">
