### PR TITLE
Allow using Examples after Outline

### DIFF
--- a/Example/Tests/Features/ExampleFeatures.swift
+++ b/Example/Tests/Features/ExampleFeatures.swift
@@ -53,6 +53,31 @@ final class ExampleFeatures: XCTestCase {
         }
     }
 
+    func testExamplesAfterOutline() {
+        // Examples can be passed after Outline via trailing closure
+
+        // swiftlint:disable multiple_closures_with_trailing_closure
+        Outline({
+            Given("I use the example name <name>")
+            Then("The age should be <age>")
+        }) {[
+            [ "name",   "age", "height" ],
+            [  "Alice",  "20",  "170"   ],
+            [  "Bob",    "20",  "170"   ]
+            ]}
+        // swiftlint:enable multiple_closures_with_trailing_closure
+
+        // or via explicit Examples parameter
+        Outline({
+            Given("I use the example name <name>")
+            Then("The age should be <age>")
+        }, Examples:
+            [ "name",   "age", "height" ],
+           [  "Alice",  "20",  "170"   ],
+           [  "Bob",    "20",  "170"   ]
+        )
+    }
+
     func testReusableExamples2() {
         Examples(examples)
         

--- a/Example/XCTest-Gherkin.xcodeproj/project.pbxproj
+++ b/Example/XCTest-Gherkin.xcodeproj/project.pbxproj
@@ -464,7 +464,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "pushd \"${SRCROOT}/..\"\n    ./scripts/lint\n    exit $?\npopd";
+			shellScript = "pushd \"${SRCROOT}/..\"\n    ./scripts/lint\n#exit $?\npopd";
 		};
 		4A3C67E5CC96F27175DCF5DB /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -210,6 +210,7 @@ public extension XCTestCase {
      
      */
     func Examples(_ values: [[String]]) {
+        precondition(state.examples == nil, "You can't use several Examples one after each other")
         precondition(values.count > 1, "You must pass at least one set of example data")
         
         // Split out the titles and the example data
@@ -244,14 +245,28 @@ public extension XCTestCase {
         
         precondition(state.examples != nil, "You need to define examples before running an Outline block - use Examples(...)");
         precondition(state.examples!.count > 0, "You've called Examples but haven't passed anything in. Nice try.")
-        
+
         state.examples!.forEach { example in
             state.currentExample = example
             routine()
             state.currentExample = nil
         }
+        state.examples = nil
     }
-    
+
+    func Outline(_ routine: ()->(), Examples titles: [String], _ allValues: [String]...) {
+        Outline(routine, Examples: [titles] + allValues)
+    }
+
+    func Outline(_ routine: ()->(), _ allValues: () -> [[String]]) {
+        Outline(routine, Examples: allValues())
+    }
+
+    func Outline(_ routine: ()->(), Examples allValues: [[String]]) {
+        Examples(allValues)
+        Outline(routine)
+    }
+
 }
 
 private var automaticScreenshotsBehaviour: AutomaticScreenshotsBehaviour = .none

--- a/README.md
+++ b/README.md
@@ -114,7 +114,31 @@ func testOutlineTests() {
 
 This will run the tests twice, once with the values `Alice,20` and once with the values `Bob,20`.
 
-NB The examples have to be defined _before_ the `Outline {..}` whereas in Gherkin you specify them afterwards. Sorry about that.
+The easiest way to use `Examples` and `Outline` functions is to call `Examples` before `Outline`. But in Gherkin feature files Examples always go after Scenario Outline. If you want to keep this order in native tests (and don't care about little bit funky Xcode indentation) you can provide examples after defining Outline via trailing closure or explicit `Examples` parameter:
+
+```swift
+func testOutlineTests() {
+    Outline({
+        Given("I use the example name <name>")
+        Then("The age should be <age>")
+    }) {[
+        [ "name",   "age", "height" ],
+        [  "Alice",  "20",  "170"   ],
+        [  "Bob",    "20",  "170"   ]
+        ]}
+        
+    // or
+    
+    Outline({
+        Given("I use the example name <name>")
+        Then("The age should be <age>")
+    }, Examples:
+         [ "name",   "age", "height" ],
+        [  "Alice",  "20",  "170"   ],
+        [  "Bob",    "20",  "170"   ]
+    )
+}
+```
 
 ### Dealing with errors / debugging tests
 


### PR DESCRIPTION
I noticed that there was an attempt in #14 to implement this to follow more closely standard Gherkin syntax, but it does not work well with escaping closures, so here is an alternative solution with trailing closure or parameters to pass examples after outline. Xcode indentation is a bit funky in these cases, so I'm not very confident with this approach.

Original solution for that could be possible if Gherkin syntax methods are moved out of XCTestCase and become global functions, but that will require storing a reference to currently executing test case in global variable which may lead to more complicated implementation, and will allow using these functions out of XCTestCase implementation, so is also not ideal 🤷‍♂️ 