### PR TITLE
Print full path to step source in logs

### DIFF
--- a/Pod/Core/Step.swift
+++ b/Pod/Core/Step.swift
@@ -71,22 +71,21 @@ class Step: Hashable, Equatable, CustomDebugStringConvertible {
     }
 
     var hashValue: Int {
-        get {
-            return expression.hashValue
-        }
+        return expression.hashValue
     }
     
     var debugDescription: String {
-        get {
-            return "/\(expression)/  \(locationDescription)"
-        }
+        return "/\(expression)/  \(shortLocationDescription)"
     }
 
-    var locationDescription: String {
-        // We only want the output the final filename part of `file`
-        let name = (file as NSString).lastPathComponent
-        return "(\(name):\(line))"
+    var fullLocationDescription: String {
+        return "(\(file):\(line))"
     }
+
+    var shortLocationDescription: String {
+        return "(\((file as NSString).lastPathComponent):\(line))"
+    }
+
 }
 
 func ==(lhs: Step, rhs: Step) -> Bool {

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -302,10 +302,10 @@ extension XCTestCase {
         let (matches, debugDescription) = step.matches(from: match, expression: expression)
 
         // Debug the step name
-        print("    step \(keyword) \(currentStepDepthString())\(expression)  \(step.locationDescription)")
+        print("    step \(keyword) \(currentStepDepthString())\(expression)  \(step.fullLocationDescription)")
 
         // Run the step
-        XCTContext.runActivity(named: "\(keyword) \(debugDescription)  \(step.locationDescription)") { (_) in
+        XCTContext.runActivity(named: "\(keyword) \(debugDescription)  \(step.shortLocationDescription)") { (_) in
             state.currentStepDepth += 1
             state.currentStepLocation = (file, line)
             if automaticScreenshotsBehaviour.contains(.beforeStep) {


### PR DESCRIPTION
This can be helpful for some tools to allow a quick jump to step source. Activity logs still use short version with just a file name