### PR TITLE
Fix PageObject name property

### DIFF
--- a/Example/Tests/StringGherkinExtensionTests.swift
+++ b/Example/Tests/StringGherkinExtensionTests.swift
@@ -61,4 +61,13 @@ class StringGherkinExtensionTests: XCTestCase {
         let simpleString = ""
         XCTAssertEqual("", simpleString.camelCaseify)
     }
+    
+    func testHumanReadbleString_separatesWordsWithSpaces() {
+        XCTAssertEqual("Camel Case String 123 abc 456", "camelCaseString123abc456".humanReadableString)
+        XCTAssertEqual("Snake Case String Abc 123 abc 456", "snake_case_string_abc123abc456".humanReadableString)
+    }
+    
+    func testHumanReadableString_doesNotTransformAlreadyReadableString() {
+        XCTAssertEqual("Camel Case String 123 abc 456", "camelCaseString123abc456".humanReadableString.humanReadableString)
+    }
 }

--- a/Example/XCTest-Gherkin_ExampleUITests/StepDefinitions/UITestStepDefinitions.swift
+++ b/Example/XCTest-Gherkin_ExampleUITests/StepDefinitions/UITestStepDefinitions.swift
@@ -47,6 +47,10 @@ final class InitialScreenPageObject: PageObject {
 
     let app = XCUIApplication()
 
+    class override var name: String {
+        return "Initial Screen"
+    }
+    
     override func isPresented() -> Bool {
         return tryWaitFor(element: app.buttons["PushMe"], withState: "exists == true")
     }

--- a/Pod/Core/PageObject.swift
+++ b/Pod/Core/PageObject.swift
@@ -9,12 +9,12 @@ open class PageObject: NSObject {
 
     /// Name of the screen (or its part) that this page object represent.
     /// Default is name of this type without "PageObject" suffix, if any.
-    open static var name: String {
+    open class var name: String {
         let name = String(describing: self)
         if name.lowercased().hasSuffix("pageobject") {
-            return String(name.dropLast(10))
+            return String(name.dropLast(10)).humanReadableString
         }
-        return name
+        return name.humanReadableString
     }
 
     /// This method should be overriden by subclasses
@@ -33,7 +33,7 @@ public class CommonPageObjectsStepDefiner: StepDefiner {
         allSubclassesOf(PageObject.self).forEach { (subclass) in
             guard subclass != PageObject.self else { return }
 
-            let name = subclass.name.humanReadableString
+            let name = subclass.name
             let expression = String(format: CommonPageObjectsStepDefiner.isPresentedStepFormat, name)
             step(expression) {
                 _ = subclass.init()

--- a/Pod/Core/StringGherkinExtension.swift
+++ b/Pod/Core/StringGherkinExtension.swift
@@ -38,33 +38,40 @@ public extension String {
         }
     }
 
-    func snakeToCamelCase(_ string: String) -> String {
-        return string.components(separatedBy: "_")
+    var snakeToCamelCase: String {
+        return components(separatedBy: "_")
             .filter { !$0.isEmpty }
             .map({ $0.uppercaseFirstLetterString })
             .joined()
     }
 
     /**
-     Given `CamelCaseString` or `snake_case_string` this will return `Camel Case String`
+     Given `CaseString` or `case_string` this will return `Case String`
      
      TODO: There is probably a more efficient way to do this. Technically this is O(n) I guess, just not a very nice O(n).
      */
     var humanReadableString: String {
         get {
-            let string = snakeToCamelCase(self)
-            guard string.count > 1, let firstCharacter = string.first else { return string }
-            return String(firstCharacter) + string.dropFirst().reduce("") { (word, character) in
+            let string = self.snakeToCamelCase
+            guard string.count > 1 else { return string }
+            var words = [String]()
+            var word: String = ""
+            string.forEach { (character) in
                 let letter = String(character)
                 let lastIsLetter = !word.isEmpty && String(word.last!).rangeOfCharacter(from: .letters) != nil
                 let thisIsLetter = letter.rangeOfCharacter(from: .letters) != nil
-                if letter == letter.uppercased() && (lastIsLetter || (!lastIsLetter && thisIsLetter)) {
-                    return word + " " + letter
+                if (letter == letter.uppercased() && lastIsLetter)
+                    || (thisIsLetter && !lastIsLetter)
+                    && !word.isEmpty {
+                    words.append(word)
+                    word = letter != " " ? letter : ""
                 }
                 else {
-                    return word + letter
+                    word += letter != " " ? letter : ""
                 }
             }
+            words.append(word)
+            return words.joined(separator: " ")
         }
     }
 }


### PR DESCRIPTION
This property was wrongly using `static` attribute instead of `class` that would allow it to be overridden in subclasses. Also now overridden value is not transformed with `humanReadbleString` so that it is more predictable - returning already human readable string results in extra spaces between words (now fixed too)