### PR TITLE
Add Step overload to allow exact string matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # XCTest-Gherkin changelog
 
 ### Unreleased
++ Add `step(exact: String)` to explicitly exactly match a step instead of using regexes
 
 ### 0.17.1
 + fix for name property on PageObject (thanks @ilyapuchka)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # XCTest-Gherkin changelog
 
 ### Unreleased
-+ Add `step(exact: String)` to explicitly exactly match a step instead of using regexes
++ Add `step(exactly: String)` to explicitly exactly match a step instead of using regexes
 
 ### 0.17.1
 + fix for name property on PageObject (thanks @ilyapuchka)

--- a/Example/Tests/Features/ExampleFeatures.swift
+++ b/Example/Tests/Features/ExampleFeatures.swift
@@ -174,4 +174,9 @@ final class ExampleFeatures: XCTestCase {
         UnusedStepsTracker.shared().performSelector(onMainThread: #selector(XCTestObservation.testBundleDidFinish(_:)), with: nil, waitUntilDone: true)
     }
 
+    func testMatchingStringLiterals() {
+        /// Test that calling Given when defining the step using `step(exactly:...` will work, and won't be horribly confused by regular expression characters
+        /// in the step
+        Given(MatchStringLiteralStepDefiner.literal)
+    }
 }

--- a/Example/Tests/StepDefinitions/SanitySteps.swift
+++ b/Example/Tests/StepDefinitions/SanitySteps.swift
@@ -167,3 +167,19 @@ final class SanitySteps: StepDefiner {
 
     }
 }
+
+final class MatchStringLiteralStepDefiner: StepDefiner {
+
+    /// This is a literal, which if used as a regular expression will match pretty much everything. This tests that this doesn't happen :)
+    static let literal = "^(.*)$"
+
+    override func defineSteps() {
+        step(exactly: MatchStringLiteralStepDefiner.literal) {
+        }
+
+        /// Explicitly define a step here which contains `literal` to sanity check that the exact matcher doesn't match against substrings.
+        step(MatchStringLiteralStepDefiner.literal + " NOPE") {
+            XCTFail("This step should definitely not have matched")
+        }
+    }
+}

--- a/Example/XCTest-Gherkin.xcodeproj/xcshareddata/xcschemes/XCTest-Gherkin-Example.xcscheme
+++ b/Example/XCTest-Gherkin.xcodeproj/xcshareddata/xcschemes/XCTest-Gherkin-Example.xcscheme
@@ -67,7 +67,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "E53F47D11D020EB80077CCCD"

--- a/Example/XCTest-Gherkin.xcodeproj/xcshareddata/xcschemes/XCTest-Gherkin-Example.xcscheme
+++ b/Example/XCTest-Gherkin.xcodeproj/xcshareddata/xcschemes/XCTest-Gherkin-Example.xcscheme
@@ -67,7 +67,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "E53F47D11D020EB80077CCCD"

--- a/Example/XCTest-Gherkin.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Example/XCTest-Gherkin.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>

--- a/Pod/Core/StepDefiner.swift
+++ b/Pod/Core/StepDefiner.swift
@@ -67,7 +67,7 @@ open class StepDefiner: NSObject, XCTestObservation {
      */
     open func step(exactly exact: String, file: String = #file, line: Int = #line, f: @escaping ()->()) {
         let expression = NSRegularExpression.escapedPattern(for: exact)
-        self.test.addStep("^"+expression+"$", options: regexOptions, file: file, line: line) { _ in f() }
+        self.test.addStep("^"+expression+"$", file: file, line: line) { _ in f() }
     }
 
     /**

--- a/Pod/Core/StepDefiner.swift
+++ b/Pod/Core/StepDefiner.swift
@@ -54,6 +54,23 @@ open class StepDefiner: NSObject, XCTestObservation {
     }
 
     /**
+     Create a step which _exactly_ matches the passed in string.
+
+     Don't pass anything for file: or path: - these will be automagically filled out for you. Use it like this:
+
+         step(exactly: "Some string literal") {
+             ... some function ...
+         }
+
+     - parameter exactly: The expression to _exactly_ match against
+     - parameter f: The step definition to be run
+     */
+    open func step(exactly exact: String, file: String = #file, line: Int = #line, f: @escaping ()->()) {
+        let expression = NSRegularExpression.escapedPattern(for: exact)
+        self.test.addStep("^"+expression+"$", options: regexOptions, file: file, line: line) { _ in f() }
+    }
+
+    /**
      Create a new step with an expression that contains one or more matching groups.
      
      Don't pass anything for file: or path: - these will be automagically filled out for you. Use it like this:

--- a/README.md
+++ b/README.md
@@ -204,26 +204,40 @@ XCTestCase+Gherkin.swift:165: error: -[XCTest_Gherkin_Tests.ExampleFeatures test
 
 Sometimes, multiple steps might contain the same text. The library will match with what it thinks is the right step, but it might get it wrong. For example if you have these step definitions:
 
-```
+```swift
 step("email button") { ... }
 step("I tap the email button") { ... }
 ```
 
 When you try to run this Given
-```
+
+```swift
 func testStepAnchorMatching() {
     Given("I tap the email button")
 }
 ```
 
-it might match against the "email button" step, instead of the "I tap the email button" step. To fix this, you can anchor the regular expression to the start and end of the string using `^` and `$`, like this:
+it might match against the "email button" step, instead of the "I tap the email button" step. To fix this, there are two options.
 
+1. You can pass an exact string literal to the step definition instead of using the normal method, which treats everything as a regular expression.
+
+```swift
+step(exactly: "I tap the email button")
 ```
+
+This will match _only_ the exact text "I tap the email button". Any regular expression special characters in this string will be matched exactly.
+
+2. You can anchor the regular expression to the start and end of the string using `^` and `$`, like this:
+
+```swift
 step("^email button$") { ... }
 step("I tap the email button") { ... }
 ```
 
 Now, "I tap the email button" doesn't match the first step.
+
+This method is useful if you need to match ambiguous steps, but can't use approach (1) because you also need other features of regular expressions (i.e. pattern matching etc)
+
 
 ### Screenshots
 


### PR DESCRIPTION
This is implemented as a simple wrapper around the regular expression version of step to keep the code simple - if there is a need for optimising for performance, this can be done under the hood. However (imho) given we are waiting to the UI to update I don't think our performance issue is going to be here (this statement might be proven wrong in the future).