### PR TITLE
Fixed accessing invocation property on test methods called directly

### DIFF
--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -233,8 +233,9 @@ extension XCTestCase {
 */
 extension XCTestCase {
 
-    fileprivate  var testName: String {
-        let rawName = String(describing: self.invocation!.selector)
+    fileprivate  var testName: String? {
+        guard let selector = self.invocation?.selector else { return nil }
+        let rawName = String(describing: selector)
         let testName = rawName.hasPrefix("test") ? String(rawName.dropFirst(4)) : rawName
         return testName
     }
@@ -285,9 +286,9 @@ extension XCTestCase {
                 state.currentSuiteName = suiteName
             }
 
-            if self.testName != state.currentTestName {
+            if let testName = self.testName, testName != state.currentTestName {
                 print("  Scenario: \(testName.humanReadableString)")
-                state.currentTestName = self.testName
+                state.currentTestName = testName
                 if state.currentExample == nil {
                     performBackground()
                 }

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -80,8 +80,10 @@ open class NativeTestCase: XCGNativeInitializer {
     // MARK: Test template method
     
     func featureScenarioTest() {
-        guard let (feature, scenario) = type(of: self).featureScenarioData(self.invocation!.selector) else {
-            return
+        guard
+            let selector = self.invocation?.selector,
+            let (feature, scenario) = type(of: self).featureScenarioData(selector) else {
+                return
         }
         perform(scenario: scenario, from: feature)
     }


### PR DESCRIPTION
Resolves #103
When methods of test case are called from another test they don't have associated invocation.