### PR TITLE
Do not build with xcode 9 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,6 @@ before_install:
 
 matrix:
   include:
-  - name: "Xcode 9.4 iOS 11.3"
-    osx_image: xcode9.4
-    env: DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=11.3' UI=true
-  - name: "Xcode 9.4 iOS 10.3.1"
-    osx_image: xcode9.4
-    env: DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=10.3.1' UI=true
   - name: "Xcode 10 iOS 12.0"
     osx_image: xcode10
     env: DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=12.0' UI=true


### PR DESCRIPTION
I think it should be safe to assume that Xcode 10 and Swift 4 are used by the majority of the library users by this point.