### PR TITLE
Swift Package Manager Support added

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,86 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "XCTest_Gherkin",
+    products: [
+        .library(
+            name: "XCTest_Gherkin",
+            targets: ["XCTest_Gherkin"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "XCTest_Gherkin_ObjC",
+            dependencies: [],
+            path: "Pod",
+            exclude: [
+                "Core/Background.swift",
+                "Core/ClassHelperMethods.swift",
+                "Core/Example.swift",
+                "Core/LevenshteinDistance.swift",
+                "Core/MatchedStringRepresentable.swift",
+                "Core/PageObject.swift",
+                "Core/Step.swift",
+                "Core/StepDefiner.swift",
+                "Core/StringGherkinExtension.swift",
+                "Core/XCTestCase+Gherkin.swift",
+                "Native/Language.swift",
+                "Native/NativeExample.swift",
+                "Native/NativeFeature.swift",
+                "Native/NativeFeatureParser.swift",
+                "Native/NativeRunner.swift",
+                "Native/NativeScenario.swift",
+                "Native/NativeTestCase.swift",
+                "Native/ParseState.swift",
+                "Native/gherkin-languages.json"
+            ],
+            sources: [
+                "Core/UnusedStepsTracker.h",
+                "Core/UnusedStepsTracker.m",
+                "Native/XCGNativeInitializer.h",
+                "Native/XCGNativeInitializer.m"
+            ],
+            cSettings: [
+                .headerSearchPath("Core"),
+                .headerSearchPath("Native"),
+            ]
+        ),
+        .target(
+            name: "XCTest_Gherkin",
+            dependencies: [
+                "XCTest_Gherkin_ObjC"
+            ],
+            path: "Pod",
+            exclude: [
+                "Core/UnusedStepsTracker.h",
+                "Core/UnusedStepsTracker.m",
+                "Native/XCGNativeInitializer.h",
+                "Native/XCGNativeInitializer.m"
+            ],
+            sources: [
+                "Core/Background.swift",
+                "Core/ClassHelperMethods.swift",
+                "Core/Example.swift",
+                "Core/LevenshteinDistance.swift",
+                "Core/MatchedStringRepresentable.swift",
+                "Core/PageObject.swift",
+                "Core/Step.swift",
+                "Core/StepDefiner.swift",
+                "Core/StringGherkinExtension.swift",
+                "Core/XCTestCase+Gherkin.swift",
+                "Native/Language.swift",
+                "Native/NativeExample.swift",
+                "Native/NativeFeature.swift",
+                "Native/NativeFeatureParser.swift",
+                "Native/NativeRunner.swift",
+                "Native/NativeScenario.swift",
+                "Native/NativeTestCase.swift",
+                "Native/ParseState.swift"
+            ],
+            resources: [
+                .process("Native/gherkin-languages.json")
+            ]),
+    ]
+)

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -10,6 +10,10 @@ import Foundation
 import XCTest
 import WebKit
 
+#if canImport(XCTest_Gherkin_ObjC)
+import XCTest_Gherkin_ObjC
+#endif
+
 /**
 I wanted this to work with both KIFTestCase and UITestCase which meant extending
 UITestCase - a subclass wouldn't work with both of them.

--- a/Pod/Native/NativeTestCase.swift
+++ b/Pod/Native/NativeTestCase.swift
@@ -11,6 +11,10 @@ import ObjectiveC
 
 import XCTest
 
+#if canImport(XCTest_Gherkin_ObjC)
+import XCTest_Gherkin_ObjC
+#endif
+
 open class NativeTestCase: XCGNativeInitializer {
 
     /// Overrides XCGNativeInitializer processFeatures to create the necessary

--- a/Pod/include/XCTest-Gherkin-ObjC/UnusedStepsTracker.h
+++ b/Pod/include/XCTest-Gherkin-ObjC/UnusedStepsTracker.h
@@ -1,0 +1,1 @@
+../../Core/UnusedStepsTracker.h

--- a/Pod/include/XCTest-Gherkin-ObjC/XCGNativeInitializer.h
+++ b/Pod/include/XCTest-Gherkin-ObjC/XCGNativeInitializer.h
@@ -1,0 +1,1 @@
+../../Native/XCGNativeInitializer.h

--- a/README.md
+++ b/README.md
@@ -297,6 +297,11 @@ github "net-a-porter-mobile/XCTest-Gherkin" == 0.13.2
 
 and run `carthage bootstrap --platform iOS`. The generated framework is named `XCTest_Gherkin.framework`.
 
+### Swift Package Manager
+In your Xcode project add XCTest-Gherkin via the File -> Swift Packages -> Add package dependency... menu.
+
+Note that Xcode 12 and Swift 5.3 is a minimum requirement for using XCTest-Gherkin in combination with Swift Package Manager.
+
 ## Configuration
 
 No configuration is needed.


### PR DESCRIPTION
This makes this library available via Swift Package Manager, resolving https://github.com/net-a-porter-mobile/XCTest-Gherkin/issues/109

Since resources (a.k.a. `gherkin-languages.json`) are only available starting with Swift 5.3 this is a minimum requirement for integration.