### PR TITLE
Fixed outline tests

### DIFF
--- a/Pod/Native/NativeScenario.swift
+++ b/Pod/Native/NativeScenario.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct StepDescription {
     let keyword: String
-    let expression: String
+    var expression: String
     let file: String
     let line: Int
 }

--- a/Pod/Native/ParseState.swift
+++ b/Pod/Native/ParseState.swift
@@ -89,8 +89,9 @@ class ParseState {
                     }
                 }
 
-                // Ensuring Scenario names are unique in case the name doesn't have an Example replacement in 
-                if newName == name {
+                // Ensuring Scenario names are unique in case the name doesn't have an Example replacement in
+                let nameAlreadyExists = scenarios.firstIndex(where: { $0.name == newName })
+                if (newName == name)  || (nameAlreadyExists != nil) {
                     newName = "\(newName)-\(exampleIndex)"
                 }
                 

--- a/Pod/Native/ParseState.swift
+++ b/Pod/Native/ParseState.swift
@@ -77,7 +77,19 @@ class ParseState {
         if self.examples.isEmpty {
             scenarios.append(NativeScenario(name, steps: self.steps, index: index, tags: tags))
         } else {
-            scenarios.append(NativeScenarioOutline(name, steps: self.steps, examples: self.examples, index: index, tags: tags))
+            for exampleIndex in 0...self.examples.count - 1 {
+                var newSteps = self.steps
+                var newName = name
+                self.examples[exampleIndex].pairs.forEach { (key, pair) in
+                    let toReplace = "<\(key)>"
+                    let replaceWith = pair
+                    newName = newName.replacingOccurrences(of: toReplace, with: replaceWith)
+                    for stepIndex in 0...newSteps.count - 1 {
+                        newSteps[stepIndex].expression = newSteps[stepIndex].expression.replacingOccurrences(of: toReplace, with: replaceWith)
+                    }
+                }
+                scenarios.append(NativeScenario(newName, steps: newSteps, index: index, tags: tags))
+            }
         }
         
         self.name = nil

--- a/Pod/Native/ParseState.swift
+++ b/Pod/Native/ParseState.swift
@@ -88,6 +88,12 @@ class ParseState {
                         newSteps[stepIndex].expression = newSteps[stepIndex].expression.replacingOccurrences(of: toReplace, with: replaceWith)
                     }
                 }
+
+                // Ensuring Scenario names are unique in case the name doesn't have an Example replacement in 
+                if newName == name {
+                    newName = "\(newName)-\(exampleIndex)"
+                }
+                
                 scenarios.append(NativeScenario(newName, steps: newSteps, index: index, tags: tags))
             }
         }


### PR DESCRIPTION
I found that

- a Scenario that was an outline was only counted as one test no matter how many examples there were
- The app wasn’t being reset after completing one Example line, before starting the next

This PR fixes these by interpreting all lines of an examples table as their own Scenario