### PR TITLE
Prevent duplicate step crash

### DIFF
--- a/Pod/Core/Step.swift
+++ b/Pod/Core/Step.swift
@@ -143,7 +143,9 @@ class Step: Hashable, Equatable, CustomDebugStringConvertible {
 }
 
 func ==(lhs: Step, rhs: Step) -> Bool {
-    return lhs.expression == rhs.expression
+    return lhs.expression == rhs.expression &&
+           lhs.file == rhs.file &&
+           lhs.line == rhs.line
 }
 
 extension Collection where Element == Step {

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -274,7 +274,11 @@ extension XCTestCase {
     */
     func addStep(_ expression: String, options: NSRegularExpression.Options, file: String, line: Int, function: @escaping (StepMatches<String>)->()) {
         let step = Step(expression, options: options, file: file, line: line, function)
-        state.steps.insert(step);
+        if state.steps.contains(step) {
+            NSLog("Skipped addition of duplicate step: \(step))")
+        } else {
+            state.steps.insert(step)
+        }
     }
 
     /**


### PR DESCRIPTION
This prevents an intermittent crash we're experiencing when running tests using Feature files and multiple StepDefiner classes.

Even though there is only one step defined that matches the input, it appears that it's either being called multiple times during setup, or the parsing isn't completely accurate. Similar issue mentioned in #189.

To prevent this runtime error and subsequent crash, a conditional statement is added here to prevent the addition of duplicate steps in the Set and logging the error for debugging purposes instead.

This allows the tests to pass consistently.

<img width="917" alt="Duplicate step error" src="https://github.com/user-attachments/assets/316a4b37-a13b-418e-94a5-b53970ef7b30" />

