### PR TITLE
Prevent duplicate Step crash

### DIFF
--- a/Pod/Core/Step.swift
+++ b/Pod/Core/Step.swift
@@ -143,7 +143,9 @@ class Step: Hashable, Equatable, CustomDebugStringConvertible {
 }
 
 func ==(lhs: Step, rhs: Step) -> Bool {
-    return lhs.expression == rhs.expression
+    return lhs.expression == rhs.expression &&
+           lhs.file == rhs.file &&
+           lhs.line == rhs.line
 }
 
 extension Collection where Element == Step {

--- a/Pod/Core/XCTestCase+Gherkin.swift
+++ b/Pod/Core/XCTestCase+Gherkin.swift
@@ -274,7 +274,11 @@ extension XCTestCase {
     */
     func addStep(_ expression: String, options: NSRegularExpression.Options, file: String, line: Int, function: @escaping (StepMatches<String>)->()) {
         let step = Step(expression, options: options, file: file, line: line, function)
-        state.steps.insert(step);
+        if state.steps.contains(step) {
+            NSLog("Skipped addition of duplicate step: \(step))")
+        } else {
+            state.steps.insert(step)
+        }
     }
 
     /**


### PR DESCRIPTION
Prevent the tests from crashing due to duplicate steps being added in the Set.

Also updated the `Step` Hashable definition to ensure that the equatable properties are correctly checked for matches.

